### PR TITLE
feat: Versioning and schema evolution policy for proto changes (#geospatial-grpc-2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+Thank you for your interest in the Geospatial gRPC protocol. This guide covers how to validate and submit proto changes.
+
+## Prerequisites
+
+- [Buf CLI](https://buf.build/docs/installation) — version should match the CI workflow (see `.github/workflows/ci.yml`).
+- A proto-aware editor is recommended but not required.
+
+## Local Validation
+
+Run these before pushing:
+
+```bash
+# Lint proto definitions
+buf lint
+
+# Check formatting
+buf format --diff --exit-code
+
+# Check for breaking changes against main
+buf breaking --against '.git#branch=main'
+```
+
+All three checks run in CI and must pass for a PR to merge.
+
+## Proto Change Workflow
+
+1. Create a feature branch from `main`.
+2. Make proto changes in `geospatial/v1/`.
+3. Run the local validation commands above.
+4. Open a PR against `main`.
+
+## PR Requirements
+
+- **Conventional commits** — use prefixes like `feat:`, `fix:`, `docs:`, `chore:`.
+- **Field number documentation** — when adding fields, note the next available field number in your PR description if the numbering gap is non-obvious.
+- **Additive-with-care changes** — if you add a field to a `oneof` or add a new proto file, note the impact on generated `switch`/`match` statements in the PR description.
+
+## What Not to Change Within v1
+
+The following changes are **breaking** and require the full governance process described in [VERSIONING.md](VERSIONING.md):
+
+- Removing or renaming a field, enum value, or RPC.
+- Changing a field's type or number.
+- Moving a field into or out of a `oneof`.
+- Changing an RPC's streaming direction, request type, or response type.
+- Reusing a reserved field number or name.
+
+## C# / .NET AOT Considerations
+
+The primary consumer of this protocol uses .NET NativeAOT compilation. To preserve compatibility:
+
+- **Use typed messages** — avoid `google.protobuf.Any` and `google.protobuf.Struct`, which require runtime reflection.
+- **Preserve the `oneof` pattern** — the existing proto surface uses concrete typed `oneof` discriminators. New messages should follow the same pattern.
+- **Test with trimming in mind** — avoid patterns that rely on reflection-based serialization.
+
+## Versioning Policy
+
+For the full versioning, deprecation, and breaking-change governance policy, see [VERSIONING.md](VERSIONING.md).

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,99 @@
+# Versioning and Schema Evolution Policy
+
+This document governs how the `geospatial.v1` proto surface evolves.
+It is the canonical reference for maintainers and contributors making proto changes.
+
+## Version Numbering
+
+| Component | Format | Example |
+|-----------|--------|---------|
+| Proto package | `geospatial.v<MAJOR>` | `geospatial.v1` |
+| Git release tag | `v<MAJOR>.<MINOR>.<PATCH>` | `v1.2.0` |
+
+- **MAJOR** — matches the proto package major version (currently `1`).
+- **MINOR** — additive proto surface changes (new fields, enums, RPCs, messages).
+- **PATCH** — documentation-only, comment, or config changes with no proto surface impact.
+
+> **Note:** Earlier releases used CalVer tags (`v<YYYY.MM.DD>-<hash>`).
+> New releases follow semver. Existing CalVer tags remain for historical reference.
+
+## Compatibility Guarantees Within a Major Version
+
+Within `geospatial.v1`, all tagged releases guarantee:
+
+- **Wire compatibility** — existing serialized messages remain deserializable.
+- **JSON mapping stability** — field names used in JSON serialization do not change.
+- **Field number stability** — numbers are never reused for different semantics.
+- **Enum value stability** — numeric values are never reused for different semantics.
+- **RPC surface stability** — method names, request types, and response types do not change.
+
+**Not guaranteed:**
+
+- Generated source-code API names (language plugin concern).
+- Default values of newly added fields.
+- Ordering of elements in repeated fields.
+
+**Consumer contract:** any tag within the same MAJOR version is safe to upgrade without application code changes.
+
+## Change Classification
+
+| Category | Examples | Version Bump | Process |
+|----------|----------|:------------:|---------|
+| **Additive** | New optional field, new enum value, new RPC, new message, new service | Minor | Standard PR review |
+| **Additive-with-care** | New field in a `oneof`, new proto file in `geospatial/v1/` | Minor | PR description must note impact on generated `switch`/`match` |
+| **Documentation** | Comment changes, spec updates | Patch | Standard PR review |
+| **Breaking** | Remove/rename field, change field type/number, move field into/out of `oneof`, change streaming direction, change request/response type, reuse reserved number | New major | Full governance gate (see below) |
+
+## Deprecation Policy
+
+1. Add the `[deprecated = true]` field option to the element.
+2. Add a comment: `// Deprecated since v1.<MINOR>. Use <replacement> instead. Removal target: v2.`
+3. The deprecated annotation must remain for **at least two subsequent minor releases** before removal in the next major version.
+4. Deprecated elements must continue to function identically on the wire within their major version.
+
+## Field Number Reservation
+
+When a field is removed in a new major version:
+
+1. Add `reserved <number>;` and `reserved "<field_name>";` to the message.
+2. Document the removal version and reason in a comment above the reservation.
+3. Reserved numbers and names must never be reused.
+
+Within a major version, fields are never removed — only deprecated (see above).
+
+## Breaking Change Governance
+
+Breaking changes follow a structured process:
+
+1. **Proposal** — open a GitHub issue titled `Breaking change proposal: <summary>` with label `breaking-change-proposal`. Include:
+   - What changes and why.
+   - Affected messages, fields, or RPCs.
+   - Migration path for consumers.
+   - Cross-language impact, specifically C# / .NET AOT and trimming considerations.
+
+2. **Deprecation first** — the element must be deprecated in `v1` per the deprecation policy above before removal.
+
+3. **Maintainer approval** — at least one maintainer must comment `LGTM-breaking` on the proposal issue.
+
+4. **New package** — create `geospatial/v2/` alongside `geospatial/v1/`. The prior major version is frozen (critical fixes only). Both coexist in the repository.
+
+5. **CI update** — update `buf.yaml` breaking-check configuration for per-package baselines.
+
+6. **Migration guide** — the PR must include `docs/migration-v1-to-v2.md`.
+
+## Release Process
+
+- Every merge to `main` that modifies `.proto` files should result in a tagged semver release.
+- Documentation-only changes may be batched into a single patch release.
+
+## CI Enforcement
+
+The following automated checks run on every PR and are not optional:
+
+| Check | Purpose |
+|-------|---------|
+| `buf lint` | Style and API design rules (DEFAULT category, minus documented exceptions) |
+| `buf breaking --against '.git#branch=<base>'` | Wire + JSON compatibility against the target branch |
+| `buf format --diff --exit-code` | Consistent formatting |
+
+CI catches accidental breakage. This policy adds the human governance layer for **intentional** breakage, deprecation tracking, field reservation, and consumer-facing compatibility promises.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -249,17 +249,18 @@ message QueryFeaturesRequest {
 
 ## Versioning
 
-### Protocol Versioning
+The protocol is versioned by its proto package (`geospatial.v1`).
+Within a major version, all releases maintain **wire and JSON compatibility**:
+existing serialized messages remain deserializable, and JSON field names do not change.
 
-- **Package Versioning**: `geospatial.v1`, `geospatial.v2`
-- **Backward Compatibility**: New fields are optional
-- **Breaking Changes**: Require new major version
+| Change Type | Examples | Compatibility |
+|-------------|----------|:-------------:|
+| Additive | New optional field, new enum value, new RPC | Safe within major version |
+| Documentation | Comment or spec updates | Safe within major version |
+| Breaking | Remove/rename field, change type/number | Requires new major version |
 
-### Schema Evolution
-
-- **Additive Changes**: Add optional fields, new enum values
-- **Compatible Changes**: Add new service methods
-- **Breaking Changes**: Remove fields, change field types
+For the full versioning policy, deprecation rules, and breaking-change governance process,
+see [`VERSIONING.md`](../VERSIONING.md).
 
 ## Implementation Guidelines
 


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #2
## Summary

Versioning and schema evolution policy for proto changes
## Changes Made

- Versioning and schema evolution policy for proto changes
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Breaking Changes

None
## Additional Context

Decisions:
- **Stage only, do not commit**: Staging resolves the review finding (files will be part of the same commit). The actual commit is deferred to the workflow's commit step.

Follow-ons:
- **CI semver tag automation** — `ci.yml` still generates CalVer tags; needs a follow-up ticket to produce semver tags matching the policy in `VERSIONING.md`.
- **CHANGELOG** — no changelog created in this ticket; consider adding one in a follow-up.

Code kaizen:
Skipped for docs/discovery delivery.
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
