### PR TITLE
feat: Define render, builder, and deployment contracts (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The **Geospatial gRPC Standard** aims to democratize geospatial development by p
 - **Mobile data collection**: Modern alternative to OpenRosa XML forms
 - **Process execution**: Validate, dry-run, and execute geospatial analysis workflows
 - **Data publishing**: Ingest, transform, and publish geospatial datasets
+- **Map rendering**: Compose deterministic, MapLibre-compatible `MapPackage` bundles
+- **Application building**: Synthesize `AppPackage` bundles from templates and data bindings
+- **Deployment**: Promote packages to live targets with health telemetry and rollback
 - **Real-time collaboration**: Multi-user editing and synchronization
 - **Cross-platform compatibility**: Native mobile, web, and desktop apps
 
@@ -34,6 +37,9 @@ The **Geospatial gRPC Standard** aims to democratize geospatial development by p
 | `FormService` | Mobile data collection | Dynamic forms, validation, collaboration |
 | `ProcessService` | Geospatial process execution | Plan validation, dry-run, sync/streaming/async execution |
 | `PipelineService` | Data publishing pipelines | Pipeline validation, dry-run, stage-by-stage execution |
+| `RenderService` | Map composition and packaging | Render validation, dry-run, streaming execution, produces `MapPackage` |
+| `BuilderService` | Application bundle synthesis | Build validation, dry-run, streaming execution, produces `AppPackage` |
+| `DeploymentService` | Deployment promotion and lifecycle | Validation, dry-run, streaming execution, rollback, health telemetry |
 
 ### Key Message Types
 
@@ -41,6 +47,7 @@ The **Geospatial gRPC Standard** aims to democratize geospatial development by p
 - **Feature**: Attributes + geometry with flexible typing
 - **Form Controls**: Rich input types (location, media, validation)
 - **Execution Types**: Plans, steps, jobs, artifacts, provenance, and structured errors
+- **Packaging Types**: `MapPackage`, `AppPackage`, `DeploymentSpec` canonical domain objects shared across render, build, and deployment
 - **Mobile Optimizations**: Battery, network, and device-aware
 
 ## 🚀 Quick Start
@@ -50,13 +57,17 @@ The **Geospatial gRPC Standard** aims to democratize geospatial development by p
 ```bash
 # View proto definitions
 ls geospatial/v1/
-# ├── common.proto            # Shared types
-# ├── spatial_types.proto     # Geometry definitions
-# ├── feature_service.proto   # Feature CRUD
-# ├── form_service.proto      # Mobile forms
-# ├── execution_types.proto   # Shared execution infrastructure
-# ├── process_service.proto   # Process execution
-# └── pipeline_service.proto  # Data publishing pipelines
+# ├── common.proto              # Shared types
+# ├── spatial_types.proto       # Geometry definitions
+# ├── feature_service.proto     # Feature CRUD
+# ├── form_service.proto        # Mobile forms
+# ├── execution_types.proto     # Shared execution infrastructure
+# ├── packaging_types.proto     # MapPackage, AppPackage, DeploymentSpec
+# ├── process_service.proto     # Process execution
+# ├── pipeline_service.proto    # Data publishing pipelines
+# ├── render_service.proto      # Map composition and packaging
+# ├── builder_service.proto     # Application bundle synthesis
+# └── deployment_service.proto  # Deployment promotion and lifecycle
 ```
 
 ### 2. Generate Client Libraries
@@ -156,14 +167,18 @@ for feature in response.features:
 
 ```
 geospatial-grpc/
-├── geospatial/v1/              # Protocol definitions
-│   ├── common.proto            # Shared types and enums
-│   ├── spatial_types.proto     # Geometry types
-│   ├── feature_service.proto   # Feature CRUD operations
-│   ├── form_service.proto      # Mobile data collection
-│   ├── execution_types.proto   # Shared execution infrastructure
-│   ├── process_service.proto   # Geospatial process execution
-│   └── pipeline_service.proto  # Data publishing pipelines
+├── geospatial/v1/                # Protocol definitions
+│   ├── common.proto              # Shared types and enums
+│   ├── spatial_types.proto       # Geometry types
+│   ├── feature_service.proto     # Feature CRUD operations
+│   ├── form_service.proto        # Mobile data collection
+│   ├── execution_types.proto     # Shared execution infrastructure
+│   ├── packaging_types.proto     # MapPackage, AppPackage, DeploymentSpec
+│   ├── process_service.proto     # Geospatial process execution
+│   ├── pipeline_service.proto    # Data publishing pipelines
+│   ├── render_service.proto      # Map composition and packaging
+│   ├── builder_service.proto     # Application bundle synthesis
+│   └── deployment_service.proto  # Deployment promotion and lifecycle
 ├── docs/                       # Protocol documentation
 ├── examples/                   # Language-specific examples
 ├── gen/                        # Generated client libraries

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -416,14 +416,17 @@ var channel = GrpcChannel.ForAddress("https://api.production.com", new GrpcChann
 });
 ```
 
-## Step 10: Process Execution and Pipelines
+## Step 10: Process, Pipeline, Render, Build, and Deployment Workflows
 
-The protocol includes two services for server-side execution workflows:
+The protocol includes five services for server-side execution workflows:
 
 - **`ProcessService`** — validate, dry-run, and execute geospatial analysis plans (synchronous, streaming, or async job)
 - **`PipelineService`** — validate, dry-run, and execute data publishing pipelines with stage-by-stage progress
+- **`RenderService`** — compose maps and produce a canonical `MapPackage` with streaming progress
+- **`BuilderService`** — synthesize an `AppPackage` from templates, intent, and data bindings
+- **`DeploymentService`** — promote `AppPackage`/`MapPackage`/`ArtifactRef` to live targets with rollback and health telemetry
 
-Both services share execution infrastructure defined in `execution_types.proto`: job lifecycle states, structured errors with retryability guidance, artifact references, and provenance records.
+All five services share execution infrastructure defined in `execution_types.proto` (job lifecycle states, structured errors with retryability guidance, artifact references, provenance records) and follow the same `Validate*` / `DryRun*` / `Execute*` / `Execute*Stream` / `Submit*Job` / `Get*Job` / `Get*JobResult` / `Cancel*Job` RPC surface. Canonical packaging shapes (`MapPackage`, `AppPackage`, `DeploymentSpec`) live in `packaging_types.proto`. The example below uses `ProcessService`; render, build, and deploy follow the same pattern with their own spec types (`RenderSpec`, `BuildSpec`, `DeploymentSpec`).
 
 ### Validate and Dry-Run a Plan
 
@@ -614,7 +617,7 @@ switch (response.OutcomeCase)
 }
 ```
 
-See the [Protocol Specification](specification.md) for the full RPC surface, streaming execution, async job management, and pipeline definitions.
+See the [Protocol Specification](specification.md) for the full RPC surface, streaming execution, async job management, pipeline definitions, and the render/build/deployment contracts (including `MapPackage`, `AppPackage`, `DeploymentSpec`, rollback, and deployment health telemetry).
 
 ## Next Steps
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -224,7 +224,7 @@ A `RenderSpec` describes a map composition: `style_spec` (MapLibre style hints a
 
 #### Render Results
 
-`RenderResult` contains: `result_id`, terminal `status`, human-readable `summary`, any `assumptions` recorded during execution, the produced `map_package` (a canonical `MapPackage`), produced `artifacts`, per-stage `stage_results`, and a `ProvenanceRecord`. When `RenderSpec.preview_only` is true, `map_package` may be unset and the preview artifact is carried on `MapPackage.preview_artifact` instead of the packaged outputs.
+`RenderResult` contains: `result_id`, terminal `status`, human-readable `summary`, any `assumptions` recorded during execution, the produced `map_package` (a canonical `MapPackage`), produced `artifacts`, per-stage `stage_results`, and a `ProvenanceRecord`. `map_package` is always populated on successful execution. When `RenderSpec.preview_only` is true, only `MapPackage.preview_artifact` is guaranteed to be set; the packaged outputs (`map_artifact`, `style_artifact`) MAY be empty.
 
 #### MapPackage Contract
 
@@ -337,7 +337,7 @@ Every deployment request also carries a `DeploymentOperationMode` (`CREATE`, `UP
 
 #### Deployment Validation and Dry-Run Semantics
 
-`ValidateDeployment` and `DryRunDeployment` are advisory. Servers re-validate the deployment spec on `ExecuteDeployment`, `ExecuteDeploymentStream`, `SubmitDeploymentJob`, and `RollbackDeployment`. `DryRunDeployment` returns the validation outcome alongside a `DryRunResult`.
+`ValidateDeployment` and `DryRunDeployment` are advisory. Servers re-validate the deployment spec on `ExecuteDeployment`, `ExecuteDeploymentStream`, and `SubmitDeploymentJob`. `DryRunDeployment` returns the validation outcome alongside a `DryRunResult`. `RollbackDeployment` does not re-validate a deployment spec (it does not carry one); instead, servers validate rollback-specific request fields — `INVALID_ARGUMENT` for malformed input (e.g., missing `deployment_id`), `NOT_FOUND` for an unknown `deployment_id` or `target_revision`, and `FAILED_PRECONDITION` if the deployment is not in a state that permits rollback.
 
 #### Deployment Results
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -191,7 +191,7 @@ A `PipelineDefinition` describes a data publishing workflow with a source, trans
 
 ### RenderService
 
-The `RenderService` provides typed RPC access to map composition and packaging. It produces a `MapPackage` — a deterministic, MapLibre-compatible map composition — that downstream runtimes can hydrate without interpretation drift. It supports:
+The `RenderService` provides typed RPC access to map composition and packaging. A non-preview render produces a hydration-ready `MapPackage` — a deterministic, MapLibre-compatible map composition — that downstream runtimes can hydrate without interpretation drift. Preview-only renders return a preview-focused `MapPackage` intended for console/UI previews that is not hydration-ready (see [MapPackage Contract](#mappackage-contract)). It supports:
 
 - **Render Validation**: Check a render spec for structural and capability issues
 - **Dry-Run Estimation**: Estimate the cost and artifact footprint of a render without side effects
@@ -224,7 +224,7 @@ A `RenderSpec` describes a map composition: `style_spec` (MapLibre style hints a
 
 #### Render Results
 
-`RenderResult` contains: `result_id`, terminal `status`, human-readable `summary`, any `assumptions` recorded during execution, the produced `map_package` (a canonical `MapPackage`), produced `artifacts`, per-stage `stage_results`, and a `ProvenanceRecord`. `map_package` is always populated on successful execution. When `RenderSpec.preview_only` is true, only `MapPackage.preview_artifact` is guaranteed to be set; the packaged outputs (`map_artifact`, `style_artifact`) MAY be empty.
+`RenderResult` contains: `result_id`, terminal `status`, human-readable `summary`, any `assumptions` recorded during execution, the produced `map_package` (a canonical `MapPackage`), produced `artifacts`, per-stage `stage_results`, and a `ProvenanceRecord`. `map_package` is always populated on successful execution. For non-preview renders, the returned `MapPackage` is hydration-ready (`map_artifact` and `style_artifact` are set). When `RenderSpec.preview_only` is true, only `MapPackage.preview_artifact` is guaranteed to be set; the packaged outputs (`map_artifact`, `style_artifact`) MAY be empty and the returned `MapPackage` is not hydration-ready.
 
 #### MapPackage Contract
 
@@ -239,10 +239,12 @@ A `RenderSpec` describes a map composition: `style_spec` (MapLibre style hints a
 
 MapLibre style JSON is carried as opaque bytes inside `style_artifact`, not typed proto fields, so MapPackage evolution is decoupled from upstream MapLibre releases.
 
+A `MapPackage` is hydration-ready only when both `map_artifact` and `style_artifact` are set. Preview-focused results from `RenderService` with `RenderSpec.preview_only = true` are the single documented exception: only `preview_artifact` is guaranteed, and such a package must not be treated as hydration-ready. Hydrating consumers operate on non-preview `MapPackage` instances or gate on `map_artifact` and `style_artifact` being populated.
+
 #### Consumer Expectations
 
 - `honua-server-731` packages `MapPackage` outputs without redefining its shape.
-- `honua-sdk-js-21` hydrates a MapLibre runtime directly from a `MapPackage`, keying compatibility on `MapPackage.spec_version`.
+- `honua-sdk-js-21` hydrates a MapLibre runtime directly from a non-preview `MapPackage`, keying compatibility on `MapPackage.spec_version`.
 - MCP extensions and the operator orchestration host call `ExecuteRender` / `ExecuteRenderStream` without wrapping them in bespoke render shapes.
 
 ### BuilderService
@@ -331,7 +333,7 @@ service DeploymentService {
 
 #### Deployment Specs
 
-A `DeploymentSpec` captures the desired state of a running deployment: `deployment_id`, `spec_version`, a `package_ref` oneof (`AppPackage`, `MapPackage`, or `ArtifactRef` — which handles `SERVICE_DEFINITION` and other deployable artifact classes), a `DeploymentTarget` (logical target with `environment` and `region`; cloud backend specifics are intentionally out of scope), a `DeploymentStrategy` (`IMMEDIATE`, `BLUE_GREEN`, `CANARY`, `ROLLING`), one or more `HealthCheck` probes, and a `RollbackPolicy`.
+A `DeploymentSpec` captures the desired state of a running deployment: `deployment_id`, `spec_version`, a `package_ref` oneof (`AppPackage`, `MapPackage`, or `ArtifactRef` — which handles `SERVICE_DEFINITION` and other deployable artifact classes), a `DeploymentTarget` (logical target with `environment` and `region`; cloud backend specifics are intentionally out of scope), a `DeploymentStrategy` (`IMMEDIATE`, `BLUE_GREEN`, `CANARY`, `ROLLING`), one or more `HealthCheck` probes, a `RollbackPolicy`, and a `workspace_ref` consistent with `ArtifactRef.workspace_ref` (matching the convention on `MapPackage` and `AppPackage`).
 
 Every deployment request also carries a `DeploymentOperationMode` (`CREATE`, `UPDATE`, `REDEPLOY`) so the server can decide whether the spec represents a fresh deployment or an update.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -352,7 +352,7 @@ Every deployment request also carries a `DeploymentOperationMode` (`CREATE`, `UP
 #### Health Telemetry
 
 - `GetDeploymentHealth` returns a point-in-time health snapshot: overall `DeploymentHealthStatus` (`HEALTHY`, `DEGRADED`, `UNHEALTHY`, `UNKNOWN`), `HealthCheckResult` entries, and an `observed_at` timestamp.
-- `StreamDeploymentHealth` streams `DeploymentHealthEvent` messages continuously. Servers MAY terminate the stream with `DEADLINE_EXCEEDED` after a documented idle window; clients reconnect to resume telemetry, matching the expectations for `ExecuteRenderStream` / `ExecutePlanStream`.
+- `StreamDeploymentHealth` streams `DeploymentHealthEvent` messages continuously. Unlike the execution streams (`ExecuteDeploymentStream`, `ExecuteRenderStream`, `ExecutePlanStream`), it is not subject to the terminal in-band `ErrorDetail` contract: `DeploymentHealthEvent` carries observed health only, and terminal failures surface as non-OK gRPC status codes. Servers MAY terminate the stream with `DEADLINE_EXCEEDED` after a documented idle window; clients reconnect to resume telemetry.
 
 #### Consumer Expectations
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -274,7 +274,7 @@ service BuilderService {
 
 #### Build Specs
 
-A `BuildSpec` describes an application synthesis request: `template_ref` (app template registry reference), `intent` (typed `ParameterMap` — title, summary, audience, capability flags), one or more `DataBinding` entries (typed source kind, `source_ref`, typed `selection`, role), `map_package_refs` for embedded maps, and `target_platforms` (e.g., `"web"`, `"mobile"`).
+A `BuildSpec` describes an application synthesis request: `template_ref` (app template registry reference), `intent` (typed `ParameterMap` — title, summary, audience, capability flags), one or more `DataBinding` entries for datasets or artifacts (typed source kind, `source_ref`, typed `selection`, role), `map_package_refs` for embedded maps, and `target_platforms` (e.g., `"web"`, `"mobile"`).
 
 #### Build Validation and Dry-Run Semantics
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This specification defines standardized gRPC protocols for geospatial data access, mobile field data collection, process execution, and data publishing pipelines. The protocols provide type-safe, high-performance service contracts for spatial feature CRUD, mobile forms, analysis workflow execution, and dataset publishing.
+This specification defines standardized gRPC protocols for geospatial data access, mobile field data collection, process execution, data publishing pipelines, map rendering, application building, and deployment. The protocols provide type-safe, high-performance service contracts for spatial feature CRUD, mobile forms, analysis workflow execution, dataset publishing, packaged map composition, application bundle synthesis, and deployment promotion.
 
 ## Design Principles
 
@@ -189,9 +189,178 @@ A `PipelineDefinition` describes a data publishing workflow with a source, trans
 
 `PipelineResult` contains the output of a completed pipeline execution: a `result_id`, the terminal `status` (`JobState`), a human-readable `summary`, source lineage (source reference, record count, inferred schema, spatial reference, and extent), a quality report (total, valid, invalid, cleaned, and deduplicated record counts with per-rule issues), published service information, produced `artifacts`, per-stage `stage_results`, and a `ProvenanceRecord`.
 
+### RenderService
+
+The `RenderService` provides typed RPC access to map composition and packaging. It produces a `MapPackage` — a deterministic, MapLibre-compatible map composition — that downstream runtimes can hydrate without interpretation drift. It supports:
+
+- **Render Validation**: Check a render spec for structural and capability issues
+- **Dry-Run Estimation**: Estimate the cost and artifact footprint of a render without side effects
+- **Synchronous Execution**: Run a render and receive the complete `MapPackage`
+- **Streaming Execution**: Receive progress and stage events as rendering proceeds
+- **Asynchronous Jobs**: Submit long-running renders as jobs with polling and cancellation
+
+#### Key Methods
+
+```protobuf
+service RenderService {
+  rpc ValidateRender(ValidateRenderRequest) returns (ValidateRenderResponse);
+  rpc DryRunRender(DryRunRenderRequest) returns (DryRunRenderResponse);
+  rpc ExecuteRender(ExecuteRenderRequest) returns (ExecuteRenderResponse);
+  rpc ExecuteRenderStream(ExecuteRenderRequest) returns (stream RenderEvent);
+  rpc SubmitRenderJob(SubmitRenderJobRequest) returns (SubmitRenderJobResponse);
+  rpc GetRenderJob(GetRenderJobRequest) returns (GetRenderJobResponse);
+  rpc GetRenderJobResult(GetRenderJobResultRequest) returns (GetRenderJobResultResponse);
+  rpc CancelRenderJob(CancelRenderJobRequest) returns (CancelRenderJobResponse);
+}
+```
+
+#### Render Specs
+
+A `RenderSpec` describes a map composition: `style_spec` (MapLibre style hints as a typed `ParameterMap`), one or more `LayerBinding` entries (typed source kind, `source_ref`, typed `filter`, typed `style_overrides`), a `target_spatial_reference`, an optional `target_extent`, and a `preview_only` flag. The typed `ParameterValue` branches (`spatial_filter_value`, `spatial_reference_value`, `geometry_value`, `extent_value`) apply here the same way they do to `PlanStep` inputs.
+
+#### Render Validation and Dry-Run Semantics
+
+`ValidateRender` and `DryRunRender` are advisory, matching `ValidatePlan` and `DryRunPlan`. Servers re-validate the render spec on `ExecuteRender`, `ExecuteRenderStream`, and `SubmitRenderJob`. `DryRunRender` returns the validation outcome alongside a `DryRunResult`.
+
+#### Render Results
+
+`RenderResult` contains: `result_id`, terminal `status`, human-readable `summary`, any `assumptions` recorded during execution, the produced `map_package` (a canonical `MapPackage`), produced `artifacts`, per-stage `stage_results`, and a `ProvenanceRecord`. When `RenderSpec.preview_only` is true, `map_package` may be unset and the preview artifact is carried on `MapPackage.preview_artifact` instead of the packaged outputs.
+
+#### MapPackage Contract
+
+`MapPackage` is the canonical map composition object shared across services and consumer SDKs:
+
+- `package_id`, `spec_version` — stable identifier and MapPackage contract version (independent of the proto package version)
+- `map_artifact`, `style_artifact`, `preview_artifact` — `ArtifactRef` handles for the packaged map bundle, the MapLibre style JSON, and an optional preview
+- `spatial_reference`, `extent` — canonical CRS and envelope
+- `source_refs` — upstream dataset references for provenance lookups
+- `metadata` — free-form display metadata (title, description, attribution)
+- `workspace_ref` — workspace handle consistent with `ArtifactRef.workspace_ref`
+
+MapLibre style JSON is carried as opaque bytes inside `style_artifact`, not typed proto fields, so MapPackage evolution is decoupled from upstream MapLibre releases.
+
+#### Consumer Expectations
+
+- `honua-server-731` packages `MapPackage` outputs without redefining its shape.
+- `honua-sdk-js-21` hydrates a MapLibre runtime directly from a `MapPackage`, keying compatibility on `MapPackage.spec_version`.
+- MCP extensions and the operator orchestration host call `ExecuteRender` / `ExecuteRenderStream` without wrapping them in bespoke render shapes.
+
+### BuilderService
+
+The `BuilderService` provides typed RPC access to application bundle synthesis. It produces an `AppPackage` — a deterministic bundle — suitable for direct deployment or for embedding `MapPackage` references. It supports:
+
+- **Build Validation**: Check a build spec for structural and capability issues
+- **Dry-Run Estimation**: Estimate the cost and artifact footprint of a build without side effects
+- **Synchronous Execution**: Run a build and receive the complete `AppPackage`
+- **Streaming Execution**: Receive progress and stage events as the build proceeds
+- **Asynchronous Jobs**: Submit long-running builds as jobs with polling and cancellation
+
+#### Key Methods
+
+```protobuf
+service BuilderService {
+  rpc ValidateBuild(ValidateBuildRequest) returns (ValidateBuildResponse);
+  rpc DryRunBuild(DryRunBuildRequest) returns (DryRunBuildResponse);
+  rpc ExecuteBuild(ExecuteBuildRequest) returns (ExecuteBuildResponse);
+  rpc ExecuteBuildStream(ExecuteBuildRequest) returns (stream BuildEvent);
+  rpc SubmitBuildJob(SubmitBuildJobRequest) returns (SubmitBuildJobResponse);
+  rpc GetBuildJob(GetBuildJobRequest) returns (GetBuildJobResponse);
+  rpc GetBuildJobResult(GetBuildJobResultRequest) returns (GetBuildJobResultResponse);
+  rpc CancelBuildJob(CancelBuildJobRequest) returns (CancelBuildJobResponse);
+}
+```
+
+#### Build Specs
+
+A `BuildSpec` describes an application synthesis request: `template_ref` (app template registry reference), `intent` (typed `ParameterMap` — title, summary, audience, capability flags), one or more `DataBinding` entries (typed source kind, `source_ref`, typed `selection`, role), `map_package_refs` for embedded maps, and `target_platforms` (e.g., `"web"`, `"mobile"`).
+
+#### Build Validation and Dry-Run Semantics
+
+`ValidateBuild` and `DryRunBuild` are advisory. Servers re-validate the build spec on `ExecuteBuild`, `ExecuteBuildStream`, and `SubmitBuildJob`. `DryRunBuild` returns the validation outcome alongside a `DryRunResult`.
+
+#### Build Results
+
+`BuildResult` contains: `result_id`, terminal `status`, human-readable `summary`, `assumptions`, the produced `app_package` (a canonical `AppPackage`), produced `artifacts`, per-stage `stage_results`, and a `ProvenanceRecord`.
+
+#### AppPackage Contract
+
+`AppPackage` is the canonical application bundle object shared across services and consumer SDKs:
+
+- `package_id`, `spec_version` — stable identifier and AppPackage contract version
+- `bundle_artifact`, `manifest_artifact` — `ArtifactRef` handles for the built static bundle and the typed manifest (routes, entry points, capabilities)
+- `map_package_refs` — identifiers of `MapPackage` instances embedded in the app
+- `runtime_config` — typed `ParameterMap` of runtime configuration (feature flags, env bindings)
+- `metadata` — free-form display metadata (title, description, icons)
+- `workspace_ref` — workspace handle consistent with `ArtifactRef.workspace_ref`
+
+#### Consumer Expectations
+
+- `honua-server-731` promotes a `BuildResult.app_package` into a packaged artifact set for deployment.
+- `honua-sdk-js-21` can discover embedded `map_package_refs` directly from the `AppPackage` and hydrate each runtime.
+- MCP extensions and the operator orchestration host call `ExecuteBuild` / `ExecuteBuildStream` without wrapping them in bespoke build shapes.
+
+### DeploymentService
+
+The `DeploymentService` provides typed RPC access to deployment promotion and lifecycle management. A deployment promotes an `AppPackage`, `MapPackage`, or other deployable `ArtifactRef` to a live target. It supports:
+
+- **Deployment Validation**: Check a deployment spec for structural and capability issues
+- **Dry-Run Estimation**: Estimate the cost and impact of a deployment without applying it
+- **Synchronous Execution**: Run a deployment and receive the complete result
+- **Streaming Execution**: Receive progress and stage events as the deployment proceeds
+- **Asynchronous Jobs**: Submit long-running deployments as jobs with polling and cancellation
+- **Rollback**: Revert to a prior deployment revision
+- **Health Telemetry**: Point-in-time snapshots and continuous streaming
+
+#### Key Methods
+
+```protobuf
+service DeploymentService {
+  rpc ValidateDeployment(ValidateDeploymentRequest) returns (ValidateDeploymentResponse);
+  rpc DryRunDeployment(DryRunDeploymentRequest) returns (DryRunDeploymentResponse);
+  rpc ExecuteDeployment(ExecuteDeploymentRequest) returns (ExecuteDeploymentResponse);
+  rpc ExecuteDeploymentStream(ExecuteDeploymentRequest) returns (stream DeploymentEvent);
+  rpc SubmitDeploymentJob(SubmitDeploymentJobRequest) returns (SubmitDeploymentJobResponse);
+  rpc GetDeploymentJob(GetDeploymentJobRequest) returns (GetDeploymentJobResponse);
+  rpc GetDeploymentJobResult(GetDeploymentJobResultRequest) returns (GetDeploymentJobResultResponse);
+  rpc CancelDeploymentJob(CancelDeploymentJobRequest) returns (CancelDeploymentJobResponse);
+  rpc RollbackDeployment(RollbackDeploymentRequest) returns (RollbackDeploymentResponse);
+  rpc GetDeploymentHealth(GetDeploymentHealthRequest) returns (GetDeploymentHealthResponse);
+  rpc StreamDeploymentHealth(StreamDeploymentHealthRequest) returns (stream DeploymentHealthEvent);
+}
+```
+
+#### Deployment Specs
+
+A `DeploymentSpec` captures the desired state of a running deployment: `deployment_id`, `spec_version`, a `package_ref` oneof (`AppPackage`, `MapPackage`, or `ArtifactRef` — which handles `SERVICE_DEFINITION` and other deployable artifact classes), a `DeploymentTarget` (logical target with `environment` and `region`; cloud backend specifics are intentionally out of scope), a `DeploymentStrategy` (`IMMEDIATE`, `BLUE_GREEN`, `CANARY`, `ROLLING`), one or more `HealthCheck` probes, and a `RollbackPolicy`.
+
+Every deployment request also carries a `DeploymentOperationMode` (`CREATE`, `UPDATE`, `REDEPLOY`) so the server can decide whether the spec represents a fresh deployment or an update.
+
+#### Deployment Validation and Dry-Run Semantics
+
+`ValidateDeployment` and `DryRunDeployment` are advisory. Servers re-validate the deployment spec on `ExecuteDeployment`, `ExecuteDeploymentStream`, `SubmitDeploymentJob`, and `RollbackDeployment`. `DryRunDeployment` returns the validation outcome alongside a `DryRunResult`.
+
+#### Deployment Results
+
+`DeploymentResult` contains: `result_id`, terminal `status`, human-readable `summary`, `assumptions`, `deployment_id`, a server-assigned `revision` tag, one or more `DeploymentEndpoint` entries, the committed `spec`, produced `artifacts` (service descriptors, manifests), per-stage `stage_results`, and a `ProvenanceRecord`.
+
+#### Rollback
+
+`RollbackDeployment` reverts a deployment to a prior revision. When `target_revision` is empty, the server selects the immediately prior successful revision. The response follows the same `outcome` oneof pattern as `ExecuteDeployment`: gRPC status is `OK` and the response carries either a `DeploymentResult` or an `ErrorDetail`.
+
+#### Health Telemetry
+
+- `GetDeploymentHealth` returns a point-in-time health snapshot: overall `DeploymentHealthStatus` (`HEALTHY`, `DEGRADED`, `UNHEALTHY`, `UNKNOWN`), `HealthCheckResult` entries, and an `observed_at` timestamp.
+- `StreamDeploymentHealth` streams `DeploymentHealthEvent` messages continuously. Servers MAY terminate the stream with `DEADLINE_EXCEEDED` after a documented idle window; clients reconnect to resume telemetry, matching the expectations for `ExecuteRenderStream` / `ExecutePlanStream`.
+
+#### Consumer Expectations
+
+- `honua-server-732` runs `DeploymentJob` workflows against this contract without redefining deployment or health shapes.
+- `honua-sdk-js-21` surfaces deployment state and health using `DeploymentResult`, `DeploymentEndpoint`, and `DeploymentHealthEvent` directly.
+- MCP extensions (`honua-server-728`, `honua-server-738`) and the operator orchestration host compose multi-service promotion flows — render → build → deploy — without redefining intermediate shapes.
+
 #### Shared Execution Infrastructure
 
-Both services share types defined in `execution_types.proto`:
+`ProcessService`, `PipelineService`, `RenderService`, `BuilderService`, and `DeploymentService` share types defined in `execution_types.proto`:
 
 - **Job lifecycle**: `JobState`, `StageState` enums and `JobProgress` messages
 - **Error model**: `ErrorDetail` with `ErrorCategory` and `Retryability` classifications
@@ -200,9 +369,13 @@ Both services share types defined in `execution_types.proto`:
 - **Provenance**: `ProvenanceRecord` with source datasets, assumptions, and timing
 - **Parameters**: `ParameterValue` (scalar/list/struct/typed geospatial) for step inputs and stage config
 
+#### Canonical Packaging Types
+
+`MapPackage`, `AppPackage`, and `DeploymentSpec` are shared across services and are defined in `packaging_types.proto`. They are shape contracts only — artifact materialization rules (where bytes live, retention, immutability guarantees) live in a separate workspace/artifact contract. Deployment health surface types (`DeploymentTarget`, `DeploymentStrategy`, `HealthCheck`, `HealthCheckResult`, `RollbackPolicy`, `DeploymentEndpoint`, `DeploymentHealthStatus`) also live in `packaging_types.proto` so they can be reused without importing service definitions.
+
 #### Execution Context
 
-Both `ExecutePlanRequest` and `ExecutePipelineRequest` accept an optional `ExecutionContext`:
+`ExecutePlanRequest`, `ExecutePipelineRequest`, `ExecuteRenderRequest`, `ExecuteBuildRequest`, and `ExecuteDeploymentRequest` each accept an optional `ExecutionContext`:
 
 - `workspace_id`: Scopes artifacts and job state to a workspace.
 - `timeout_seconds`: Server-enforced execution deadline. If the timeout is reached, the server reports it as an execution-phase error via `ErrorDetail` (see [Execution Errors](#execution-errors)).
@@ -210,7 +383,7 @@ Both `ExecutePlanRequest` and `ExecutePipelineRequest` accept an optional `Execu
 
 #### Node Identifier Convention
 
-Shared messages (`StageResult`, `PlanValidationIssue`, `ErrorDetail`) use a `node_id` field and `JobProgress` uses a `current_node_id` field to identify the plan node where an event, result, or issue originated. For `ProcessService`, the value correlates to `PlanStep.step_id`. For `PipelineService`, it correlates to `PipelineStage.stage_id`. Implementations must populate these fields with the identifier from the corresponding service-specific definition.
+Shared messages (`StageResult`, `PlanValidationIssue`, `ErrorDetail`) use a `node_id` field and `JobProgress` uses a `current_node_id` field to identify the plan node where an event, result, or issue originated. For `ProcessService`, the value correlates to `PlanStep.step_id`. For `PipelineService`, it correlates to `PipelineStage.stage_id`. For `RenderService`, `BuilderService`, and `DeploymentService`, the value correlates to an internal stage identifier chosen by the server (e.g., render stage, build phase, deployment step). Implementations must populate these fields with the identifier from the corresponding service-specific definition.
 
 ## Data Types
 
@@ -325,11 +498,11 @@ enum ValidationSeverity {
 
 ### Execution Errors
 
-Process and pipeline execution errors use a structured `ErrorDetail` model with machine-parseable codes, domain categories, and retryability classification. Execution-phase failures — errors that occur after the server begins executing a plan or pipeline — are always reported through `ErrorDetail` rather than gRPC status codes, so the structured error model is available to the client. The error surface is consistent across execution modes:
+Process, pipeline, render, build, and deployment execution errors use a structured `ErrorDetail` model with machine-parseable codes, domain categories, and retryability classification. Execution-phase failures — errors that occur after the server begins executing a plan, pipeline, render, build, or deployment — are always reported through `ErrorDetail` rather than gRPC status codes, so the structured error model is available to the client. The error surface is consistent across execution modes:
 
-- **Streaming** (`ExecutePlanStream` / `ExecutePipelineStream`): A terminal `error` event carries the `ErrorDetail`.
-- **Unary** (`ExecutePlan` / `ExecutePipeline`): The gRPC status is `OK` and the response `outcome` oneof carries either `result` or `error`. The `oneof` guarantees mutual exclusion (at most one branch is set on the wire); servers MUST populate exactly one.
-- **Async results** (`GetJobResult` / `GetPipelineJobResult`): The gRPC status is `OK` and the response `outcome` oneof carries `result` or `error` for completed/failed jobs.
+- **Streaming** (`ExecutePlanStream` / `ExecutePipelineStream` / `ExecuteRenderStream` / `ExecuteBuildStream` / `ExecuteDeploymentStream`): A terminal `error` event carries the `ErrorDetail`.
+- **Unary** (`ExecutePlan` / `ExecutePipeline` / `ExecuteRender` / `ExecuteBuild` / `ExecuteDeployment` / `RollbackDeployment`): The gRPC status is `OK` and the response `outcome` oneof carries either `result` or `error`. The `oneof` guarantees mutual exclusion (at most one branch is set on the wire); servers MUST populate exactly one.
+- **Async results** (`GetJobResult` / `GetPipelineJobResult` / `GetRenderJobResult` / `GetBuildJobResult` / `GetDeploymentJobResult`): The gRPC status is `OK` and the response `outcome` oneof carries `result` or `error` for completed/failed jobs.
 
 | Category | Description |
 |----------|-------------|
@@ -433,8 +606,9 @@ see [`VERSIONING.md`](../VERSIONING.md).
 - **Transaction Support**: Implement rollback for failed edits
 - **Connection Pooling**: Manage database connections efficiently
 - **Rate Limiting**: Protect against abuse
-- **Dry-Run Isolation**: `DryRunPlan` and `DryRunPipeline` must not modify persistent state or produce side effects
-- **Job Cancellation**: `CancelJob` / `CancelPipelineJob` is best-effort; the server should transition the job to `CANCELLED` as soon as practical but may complete the current stage first
+- **Dry-Run Isolation**: `DryRunPlan`, `DryRunPipeline`, `DryRunRender`, `DryRunBuild`, and `DryRunDeployment` must not modify persistent state or produce side effects
+- **Job Cancellation**: `CancelJob` / `CancelPipelineJob` / `CancelRenderJob` / `CancelBuildJob` / `CancelDeploymentJob` is best-effort; the server should transition the job to `CANCELLED` as soon as practical but may complete the current stage first
+- **Health Stream Lifetime**: `StreamDeploymentHealth` servers may terminate a long-lived health stream with `DEADLINE_EXCEEDED` after a documented idle window; clients are expected to reconnect
 - **Node ID Population**: Populate `node_id` in `StageResult`, `PlanValidationIssue`, and `ErrorDetail` — and `current_node_id` in `JobProgress` — with the step or stage identifier from the originating service
 
 ### Client Implementation
@@ -443,7 +617,7 @@ see [`VERSIONING.md`](../VERSIONING.md).
 - **Error Handling**: Implement retry logic with backoff; use the `retryability` field in `ErrorDetail` to decide whether to retry, revise, or abort
 - **Offline Support**: Cache data and queue operations
 - **Progress Reporting**: Show progress for long operations
-- **Streaming Consumption**: Consume `ExecutePlanStream` / `ExecutePipelineStream` events incrementally; expect interleaved `progress`, `stage_result`, and a terminal `result` or `error` event
+- **Streaming Consumption**: Consume `ExecutePlanStream` / `ExecutePipelineStream` / `ExecuteRenderStream` / `ExecuteBuildStream` / `ExecuteDeploymentStream` events incrementally; expect interleaved `progress`, `stage_result`, and a terminal `result` or `error` event. For `StreamDeploymentHealth`, expect continuous `DeploymentHealthEvent` messages and be prepared to reconnect after `DEADLINE_EXCEEDED`.
 
 ## Compliance and Standards
 

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -88,8 +88,8 @@ The example uses these NuGet packages:
 
 ## Next Steps
 
-- **Process Execution**: Use `ProcessService` to validate, dry-run, and execute analysis plans — see the [Getting Started guide](../../docs/getting-started.md#step-10-process-execution-and-pipelines)
-- **Data Publishing**: Use `PipelineService` to run data ingestion and publishing pipelines
+- **Execution Workflows**: Use `ProcessService`, `PipelineService`, `RenderService`, `BuilderService`, or `DeploymentService` — they share a `Validate*` / `DryRun*` / `Execute*` / `Execute*Stream` / `Submit*Job` / `Get*Job` / `Get*JobResult` / `Cancel*Job` RPC surface. See the [Getting Started guide](../../docs/getting-started.md#step-10-process-pipeline-render-build-and-deployment-workflows).
+- **Canonical Packaging**: Consume `MapPackage`, `AppPackage`, and `DeploymentSpec` from `packaging_types.proto` directly rather than wrapping them in bespoke shapes
 - **Explore Streaming**: Modify the example to use `QueryFeaturesStream` for large datasets
 - **Add Authentication**: Implement API key or OAuth authentication
 - **Error Retry**: Add retry logic with exponential backoff; use `ErrorDetail.Retryability` for execution errors

--- a/examples/javascript/README.md
+++ b/examples/javascript/README.md
@@ -132,8 +132,8 @@ export function useFeatureQuery(serviceId: string, layerId: number, where: strin
 
 ## Next Steps
 
-- **Process Execution**: Use `ProcessService` to validate, dry-run, and execute analysis plans — see the [Getting Started guide](../../docs/getting-started.md#step-10-process-execution-and-pipelines)
-- **Data Publishing**: Use `PipelineService` to run data ingestion and publishing pipelines
+- **Execution Workflows**: Use `ProcessService`, `PipelineService`, `RenderService`, `BuilderService`, or `DeploymentService` — they share a `Validate*` / `DryRun*` / `Execute*` / `Execute*Stream` / `Submit*Job` / `Get*Job` / `Get*JobResult` / `Cancel*Job` RPC surface. See the [Getting Started guide](../../docs/getting-started.md#step-10-process-pipeline-render-build-and-deployment-workflows).
+- **Canonical Packaging**: Consume `MapPackage`, `AppPackage`, and `DeploymentSpec` from `packaging_types.proto` directly rather than wrapping them in bespoke shapes
 - **Web Application**: Build a full mapping web app with Leaflet/Mapbox
 - **React Native**: Adapt for mobile app development
 - **Streaming**: Implement server-sent events for real-time updates

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -94,10 +94,17 @@ python/
         ├── form_service_pb2.py
         ├── form_service_pb2_grpc.py
         ├── execution_types_pb2.py
+        ├── packaging_types_pb2.py
         ├── process_service_pb2.py
         ├── process_service_pb2_grpc.py
         ├── pipeline_service_pb2.py
-        └── pipeline_service_pb2_grpc.py
+        ├── pipeline_service_pb2_grpc.py
+        ├── render_service_pb2.py
+        ├── render_service_pb2_grpc.py
+        ├── builder_service_pb2.py
+        ├── builder_service_pb2_grpc.py
+        ├── deployment_service_pb2.py
+        └── deployment_service_pb2_grpc.py
 ```
 
 ## Dependencies
@@ -239,8 +246,8 @@ async def test_error_handling():
 
 ## Next Steps
 
-- **Process Execution**: Use `ProcessService` to validate, dry-run, and execute analysis plans — see the [Getting Started guide](../../docs/getting-started.md#step-10-process-execution-and-pipelines)
-- **Data Publishing**: Use `PipelineService` to run data ingestion and publishing pipelines
+- **Execution Workflows**: Use `ProcessService`, `PipelineService`, `RenderService`, `BuilderService`, or `DeploymentService` — they share a `Validate*` / `DryRun*` / `Execute*` / `Execute*Stream` / `Submit*Job` / `Get*Job` / `Get*JobResult` / `Cancel*Job` RPC surface. See the [Getting Started guide](../../docs/getting-started.md#step-10-process-pipeline-render-build-and-deployment-workflows).
+- **Canonical Packaging**: Consume `MapPackage`, `AppPackage`, and `DeploymentSpec` from `packaging_types.proto` directly rather than wrapping them in bespoke shapes
 - **Web Framework**: Integrate with FastAPI, Django, or Flask
 - **Data Processing**: Use with pandas, geopandas for analysis
 - **Machine Learning**: Feed geospatial data to ML models

--- a/geospatial/v1/builder_service.proto
+++ b/geospatial/v1/builder_service.proto
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+import "geospatial/v1/execution_types.proto";
+import "geospatial/v1/packaging_types.proto";
+
+// BuilderService provides typed RPC access to application bundle synthesis.
+//
+// This service covers the execution lifecycle for application build
+// workflows: build validation, dry-run estimation, synchronous and streaming
+// execution, and job management. Building produces an AppPackage — a
+// deterministic bundle — suitable for direct deployment or for embedding
+// MapPackage references.
+//
+// Transport-neutral status mapping for server implementations:
+//
+// Request-phase failures (returned as non-OK gRPC status, no response body):
+//   INVALID_ARGUMENT    — malformed requests or invalid build specs on
+//                         ExecuteBuild/ExecuteBuildStream/SubmitBuildJob
+//                         (re-validation at execution time)
+//   PERMISSION_DENIED   — authorization or policy failures
+//   NOT_FOUND           — unknown template, dataset, or job references
+//   RESOURCE_EXHAUSTED  — quota or rate-limit exceeded
+//   FAILED_PRECONDITION — job not in expected state for the requested operation
+//   INTERNAL            — unexpected server errors
+//
+// Note: ValidateBuild and DryRunBuild always return gRPC status OK with a
+// structured response containing valid=false and populated issues when
+// validation fails. They do not use INVALID_ARGUMENT for spec issues.
+//
+// Execution-phase failures (after execution begins) are returned with gRPC
+// status OK: unary RPCs populate the response error field; streaming RPCs
+// send a terminal error event. This ensures the structured ErrorDetail is
+// always available to the client. DEADLINE_EXCEEDED and CANCELLED may still
+// arrive as gRPC-level codes from client deadlines or transport cancellation.
+service BuilderService {
+  // ValidateBuild checks a build spec for structural and capability issues.
+  rpc ValidateBuild(ValidateBuildRequest) returns (ValidateBuildResponse);
+
+  // DryRunBuild estimates the cost and impact of executing a build without side effects.
+  rpc DryRunBuild(DryRunBuildRequest) returns (DryRunBuildResponse);
+
+  // ExecuteBuild runs a build synchronously and returns the result.
+  rpc ExecuteBuild(ExecuteBuildRequest) returns (ExecuteBuildResponse);
+
+  // ExecuteBuildStream runs a build and streams progress events and the final result.
+  rpc ExecuteBuildStream(ExecuteBuildRequest) returns (stream BuildEvent);
+
+  // SubmitBuildJob submits a build spec for asynchronous execution and returns a job handle.
+  rpc SubmitBuildJob(SubmitBuildJobRequest) returns (SubmitBuildJobResponse);
+
+  // GetBuildJob retrieves the current state and progress of a build job.
+  rpc GetBuildJob(GetBuildJobRequest) returns (GetBuildJobResponse);
+
+  // GetBuildJobResult retrieves the results of a completed build job.
+  rpc GetBuildJobResult(GetBuildJobResultRequest) returns (GetBuildJobResultResponse);
+
+  // CancelBuildJob requests cancellation of a running or pending build job.
+  rpc CancelBuildJob(CancelBuildJobRequest) returns (CancelBuildJobResponse);
+}
+
+// DataBindingKind enumerates the source types that may back a data binding.
+enum DataBindingKind {
+  DATA_BINDING_KIND_UNSPECIFIED = 0;
+  DATA_BINDING_KIND_FEATURE_SERVICE = 1;
+  DATA_BINDING_KIND_MAP_PACKAGE = 2;
+  DATA_BINDING_KIND_ARTIFACT = 3;
+  DATA_BINDING_KIND_DATASET = 4;
+}
+
+// DataBinding describes a dataset or artifact wired into the built application.
+// Typed selection parameters use ParameterValue for type safety with the same
+// typed-branch convention as PlanStep inputs.
+message DataBinding {
+  string binding_id = 1;
+  DataBindingKind kind = 2;
+  // Dataset locator, ArtifactRef.artifact_id, or MapPackage.package_id.
+  string source_ref = 3;
+  // Typed filter or selection parameters.
+  ParameterValue selection = 4;
+  // Role within the application (e.g., primary_layer, reference_layer).
+  string role = 5;
+}
+
+// BuildSpec describes an application synthesis request.
+message BuildSpec {
+  string build_id = 1;
+  // BuildSpec contract version.
+  string spec_version = 2;
+  // Workflow family. Building uses WORKFLOW_FAMILY_BUILD; other values are
+  // reserved for forward compatibility.
+  WorkflowFamily workflow_family = 3;
+  // App template registry reference.
+  string template_ref = 4;
+  // Typed intent parameters (title, summary, audience, capability flags).
+  ParameterMap intent = 5;
+  repeated DataBinding data_bindings = 6;
+  // MapPackage identifiers to embed in the built application.
+  repeated string map_package_refs = 7;
+  // Target platforms (e.g., "web", "mobile").
+  repeated string target_platforms = 8;
+  // Free-form display metadata carried into the produced AppPackage.
+  map<string, string> metadata = 9;
+}
+
+// ValidateBuildRequest asks the server to check a build spec.
+message ValidateBuildRequest {
+  BuildSpec spec = 1;
+}
+
+// ValidateBuildResponse returns the validation outcome.
+message ValidateBuildResponse {
+  bool valid = 1;
+  repeated PlanValidationIssue issues = 2;
+}
+
+// DryRunBuildRequest asks the server to estimate build execution impact.
+message DryRunBuildRequest {
+  BuildSpec spec = 1;
+}
+
+// DryRunBuildResponse contains the validation outcome and dry-run estimation.
+message DryRunBuildResponse {
+  bool valid = 1;
+  repeated PlanValidationIssue issues = 2;
+  DryRunResult result = 3;
+}
+
+// ExecuteBuildRequest submits a build for synchronous or streaming execution.
+message ExecuteBuildRequest {
+  BuildSpec spec = 1;
+  ExecutionContext context = 2;
+}
+
+// ExecuteBuildResponse returns the complete result of synchronous execution.
+// The gRPC status is OK regardless of execution outcome. On success, only
+// result is populated; on terminal failure, only error is populated.
+message ExecuteBuildResponse {
+  string job_id = 1;
+  oneof outcome {
+    BuildResult result = 2;
+    ErrorDetail error = 3;
+  }
+}
+
+// BuildEvent is a streaming message carrying progress, stage, result, or error events.
+message BuildEvent {
+  oneof event {
+    JobProgress progress = 1;
+    StageResult stage_result = 2;
+    BuildResult result = 3;
+    ErrorDetail error = 4;
+  }
+}
+
+// BuildResult contains the output of a completed build execution.
+message BuildResult {
+  string result_id = 1;
+  JobState status = 2;
+  string summary = 3;
+  repeated Assumption assumptions = 4;
+  // Produced AppPackage.
+  AppPackage app_package = 5;
+  repeated ArtifactRef artifacts = 6;
+  repeated StageResult stage_results = 7;
+  ProvenanceRecord provenance = 8;
+}
+
+// SubmitBuildJobRequest submits a build spec for asynchronous execution.
+message SubmitBuildJobRequest {
+  BuildSpec spec = 1;
+  ExecutionContext context = 2;
+}
+
+// SubmitBuildJobResponse confirms build job submission.
+message SubmitBuildJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+}
+
+// GetBuildJobRequest retrieves the current state of a build job.
+message GetBuildJobRequest {
+  string job_id = 1;
+}
+
+// GetBuildJobResponse returns the build job state and progress.
+message GetBuildJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+  JobProgress progress = 3;
+}
+
+// GetBuildJobResultRequest retrieves the results of a completed build job.
+message GetBuildJobResultRequest {
+  string job_id = 1;
+}
+
+// GetBuildJobResultResponse returns the build job result.
+// The gRPC status is OK regardless of job outcome. For failed jobs, the
+// error field carries the structured ErrorDetail.
+message GetBuildJobResultResponse {
+  string job_id = 1;
+  oneof outcome {
+    BuildResult result = 2;
+    ErrorDetail error = 3;
+  }
+}
+
+// CancelBuildJobRequest requests cancellation of a build job.
+message CancelBuildJobRequest {
+  string job_id = 1;
+}
+
+// CancelBuildJobResponse confirms the build cancellation outcome.
+message CancelBuildJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+}

--- a/geospatial/v1/builder_service.proto
+++ b/geospatial/v1/builder_service.proto
@@ -65,20 +65,24 @@ service BuilderService {
 
 // DataBindingKind enumerates the source types that may back a data binding.
 enum DataBindingKind {
+  reserved 2;
+  reserved "DATA_BINDING_KIND_MAP_PACKAGE";
+
   DATA_BINDING_KIND_UNSPECIFIED = 0;
   DATA_BINDING_KIND_FEATURE_SERVICE = 1;
-  DATA_BINDING_KIND_MAP_PACKAGE = 2;
   DATA_BINDING_KIND_ARTIFACT = 3;
   DATA_BINDING_KIND_DATASET = 4;
 }
 
-// DataBinding describes a dataset or artifact wired into the built application.
+// DataBinding describes a dataset or artifact wired into the built
+// application. Embedded maps are supplied separately through
+// BuildSpec.map_package_refs.
 // Typed selection parameters use ParameterValue for type safety with the same
 // typed-branch convention as PlanStep inputs.
 message DataBinding {
   string binding_id = 1;
   DataBindingKind kind = 2;
-  // Dataset locator, ArtifactRef.artifact_id, or MapPackage.package_id.
+  // Dataset locator or ArtifactRef.artifact_id.
   string source_ref = 3;
   // Typed filter or selection parameters.
   ParameterValue selection = 4;
@@ -98,6 +102,7 @@ message BuildSpec {
   string template_ref = 4;
   // Typed intent parameters (title, summary, audience, capability flags).
   ParameterMap intent = 5;
+  // Dataset and artifact bindings consumed by the built application.
   repeated DataBinding data_bindings = 6;
   // MapPackage identifiers to embed in the built application.
   repeated string map_package_refs = 7;

--- a/geospatial/v1/deployment_service.proto
+++ b/geospatial/v1/deployment_service.proto
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+import "geospatial/v1/execution_types.proto";
+import "geospatial/v1/packaging_types.proto";
+
+// DeploymentService provides typed RPC access to deployment promotion and
+// lifecycle management.
+//
+// This service covers the execution lifecycle for deployment workflows:
+// deployment validation, dry-run estimation, synchronous and streaming
+// execution, job management, rollback, and continuous health telemetry.
+// A deployment promotes an AppPackage, MapPackage, or other deployable
+// ArtifactRef to a live target.
+//
+// Transport-neutral status mapping for server implementations:
+//
+// Request-phase failures (returned as non-OK gRPC status, no response body):
+//   INVALID_ARGUMENT    — malformed requests or invalid deployment specs on
+//                         ExecuteDeployment/ExecuteDeploymentStream/SubmitDeploymentJob
+//                         and RollbackDeployment (re-validation at execution time)
+//   PERMISSION_DENIED   — authorization or policy failures
+//   NOT_FOUND           — unknown deployment, revision, target, or job references
+//   RESOURCE_EXHAUSTED  — quota or rate-limit exceeded
+//   FAILED_PRECONDITION — job not in expected state for the requested operation
+//   INTERNAL            — unexpected server errors
+//
+// Note: ValidateDeployment and DryRunDeployment always return gRPC status OK
+// with a structured response containing valid=false and populated issues when
+// validation fails. They do not use INVALID_ARGUMENT for spec issues.
+//
+// Execution-phase failures (after execution begins) are returned with gRPC
+// status OK: unary RPCs populate the response error field; streaming RPCs
+// send a terminal error event. This ensures the structured ErrorDetail is
+// always available to the client. DEADLINE_EXCEEDED and CANCELLED may still
+// arrive as gRPC-level codes from client deadlines or transport cancellation.
+//
+// StreamDeploymentHealth is long-lived by design. Servers MAY terminate the
+// stream with DEADLINE_EXCEEDED after a documented idle window; clients are
+// expected to reconnect to resume telemetry.
+service DeploymentService {
+  // ValidateDeployment checks a deployment spec for structural and capability issues.
+  rpc ValidateDeployment(ValidateDeploymentRequest) returns (ValidateDeploymentResponse);
+
+  // DryRunDeployment estimates the cost and impact of executing a deployment without side effects.
+  rpc DryRunDeployment(DryRunDeploymentRequest) returns (DryRunDeploymentResponse);
+
+  // ExecuteDeployment runs a deployment synchronously and returns the result.
+  rpc ExecuteDeployment(ExecuteDeploymentRequest) returns (ExecuteDeploymentResponse);
+
+  // ExecuteDeploymentStream runs a deployment and streams progress events and the final result.
+  rpc ExecuteDeploymentStream(ExecuteDeploymentRequest) returns (stream DeploymentEvent);
+
+  // SubmitDeploymentJob submits a deployment spec for asynchronous execution and returns a job handle.
+  rpc SubmitDeploymentJob(SubmitDeploymentJobRequest) returns (SubmitDeploymentJobResponse);
+
+  // GetDeploymentJob retrieves the current state and progress of a deployment job.
+  rpc GetDeploymentJob(GetDeploymentJobRequest) returns (GetDeploymentJobResponse);
+
+  // GetDeploymentJobResult retrieves the results of a completed deployment job.
+  rpc GetDeploymentJobResult(GetDeploymentJobResultRequest) returns (GetDeploymentJobResultResponse);
+
+  // CancelDeploymentJob requests cancellation of a running or pending deployment job.
+  rpc CancelDeploymentJob(CancelDeploymentJobRequest) returns (CancelDeploymentJobResponse);
+
+  // RollbackDeployment reverts a deployment to a prior revision.
+  rpc RollbackDeployment(RollbackDeploymentRequest) returns (RollbackDeploymentResponse);
+
+  // GetDeploymentHealth returns a point-in-time health snapshot for a deployment.
+  rpc GetDeploymentHealth(GetDeploymentHealthRequest) returns (GetDeploymentHealthResponse);
+
+  // StreamDeploymentHealth streams health telemetry events for a deployment.
+  rpc StreamDeploymentHealth(StreamDeploymentHealthRequest) returns (stream DeploymentHealthEvent);
+}
+
+// DeploymentOperationMode classifies a deployment request.
+enum DeploymentOperationMode {
+  DEPLOYMENT_OPERATION_MODE_UNSPECIFIED = 0;
+  DEPLOYMENT_OPERATION_MODE_CREATE = 1;
+  DEPLOYMENT_OPERATION_MODE_UPDATE = 2;
+  DEPLOYMENT_OPERATION_MODE_REDEPLOY = 3;
+}
+
+// ValidateDeploymentRequest asks the server to check a deployment spec.
+message ValidateDeploymentRequest {
+  DeploymentSpec spec = 1;
+  DeploymentOperationMode operation_mode = 2;
+}
+
+// ValidateDeploymentResponse returns the validation outcome.
+message ValidateDeploymentResponse {
+  bool valid = 1;
+  repeated PlanValidationIssue issues = 2;
+}
+
+// DryRunDeploymentRequest asks the server to estimate deployment execution impact.
+message DryRunDeploymentRequest {
+  DeploymentSpec spec = 1;
+  DeploymentOperationMode operation_mode = 2;
+}
+
+// DryRunDeploymentResponse contains the validation outcome and dry-run estimation.
+message DryRunDeploymentResponse {
+  bool valid = 1;
+  repeated PlanValidationIssue issues = 2;
+  DryRunResult result = 3;
+}
+
+// ExecuteDeploymentRequest submits a deployment for synchronous or streaming execution.
+message ExecuteDeploymentRequest {
+  DeploymentSpec spec = 1;
+  DeploymentOperationMode operation_mode = 2;
+  ExecutionContext context = 3;
+}
+
+// ExecuteDeploymentResponse returns the complete result of synchronous execution.
+// The gRPC status is OK regardless of execution outcome. On success, only
+// result is populated; on terminal failure, only error is populated.
+message ExecuteDeploymentResponse {
+  string job_id = 1;
+  oneof outcome {
+    DeploymentResult result = 2;
+    ErrorDetail error = 3;
+  }
+}
+
+// DeploymentEvent is a streaming message carrying progress, stage, result, or error events.
+message DeploymentEvent {
+  oneof event {
+    JobProgress progress = 1;
+    StageResult stage_result = 2;
+    DeploymentResult result = 3;
+    ErrorDetail error = 4;
+  }
+}
+
+// DeploymentResult contains the output of a completed deployment execution.
+message DeploymentResult {
+  string result_id = 1;
+  JobState status = 2;
+  string summary = 3;
+  repeated Assumption assumptions = 4;
+  string deployment_id = 5;
+  // Monotonic revision tag assigned by the server.
+  string revision = 6;
+  repeated DeploymentEndpoint endpoints = 7;
+  // Committed deployment spec.
+  DeploymentSpec spec = 8;
+  repeated ArtifactRef artifacts = 9;
+  repeated StageResult stage_results = 10;
+  ProvenanceRecord provenance = 11;
+}
+
+// SubmitDeploymentJobRequest submits a deployment spec for asynchronous execution.
+message SubmitDeploymentJobRequest {
+  DeploymentSpec spec = 1;
+  DeploymentOperationMode operation_mode = 2;
+  ExecutionContext context = 3;
+}
+
+// SubmitDeploymentJobResponse confirms deployment job submission.
+message SubmitDeploymentJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+}
+
+// GetDeploymentJobRequest retrieves the current state of a deployment job.
+message GetDeploymentJobRequest {
+  string job_id = 1;
+}
+
+// GetDeploymentJobResponse returns the deployment job state and progress.
+message GetDeploymentJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+  JobProgress progress = 3;
+}
+
+// GetDeploymentJobResultRequest retrieves the results of a completed deployment job.
+message GetDeploymentJobResultRequest {
+  string job_id = 1;
+}
+
+// GetDeploymentJobResultResponse returns the deployment job result.
+// The gRPC status is OK regardless of job outcome. For failed jobs, the
+// error field carries the structured ErrorDetail.
+message GetDeploymentJobResultResponse {
+  string job_id = 1;
+  oneof outcome {
+    DeploymentResult result = 2;
+    ErrorDetail error = 3;
+  }
+}
+
+// CancelDeploymentJobRequest requests cancellation of a deployment job.
+message CancelDeploymentJobRequest {
+  string job_id = 1;
+}
+
+// CancelDeploymentJobResponse confirms the deployment cancellation outcome.
+message CancelDeploymentJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+}
+
+// RollbackDeploymentRequest asks the server to revert a deployment to a prior revision.
+message RollbackDeploymentRequest {
+  string deployment_id = 1;
+  // Target revision to roll back to. If empty, the server selects the
+  // immediately prior successful revision.
+  string target_revision = 2;
+  ExecutionContext context = 3;
+}
+
+// RollbackDeploymentResponse returns the outcome of a rollback operation.
+// The gRPC status is OK regardless of execution outcome. On success, only
+// result is populated; on terminal failure, only error is populated.
+message RollbackDeploymentResponse {
+  string deployment_id = 1;
+  oneof outcome {
+    DeploymentResult result = 2;
+    ErrorDetail error = 3;
+  }
+}
+
+// GetDeploymentHealthRequest asks for a point-in-time health snapshot.
+message GetDeploymentHealthRequest {
+  string deployment_id = 1;
+  // Optional revision. When empty, the server returns health for the active revision.
+  string revision = 2;
+}
+
+// GetDeploymentHealthResponse returns a health snapshot for a deployment.
+message GetDeploymentHealthResponse {
+  string deployment_id = 1;
+  string revision = 2;
+  DeploymentHealthStatus status = 3;
+  repeated HealthCheckResult check_results = 4;
+  int64 observed_at = 5; // UTC milliseconds since epoch
+}
+
+// StreamDeploymentHealthRequest opens a continuous health telemetry stream.
+message StreamDeploymentHealthRequest {
+  string deployment_id = 1;
+  // Optional revision. When empty, the stream follows the active revision.
+  string revision = 2;
+}
+
+// DeploymentHealthEvent reports observed deployment health.
+message DeploymentHealthEvent {
+  string deployment_id = 1;
+  string revision = 2;
+  DeploymentHealthStatus status = 3;
+  repeated HealthCheckResult check_results = 4;
+  int64 observed_at = 5; // UTC milliseconds since epoch
+}

--- a/geospatial/v1/deployment_service.proto
+++ b/geospatial/v1/deployment_service.proto
@@ -22,11 +22,16 @@ import "geospatial/v1/packaging_types.proto";
 // Request-phase failures (returned as non-OK gRPC status, no response body):
 //   INVALID_ARGUMENT    — malformed requests or invalid deployment specs on
 //                         ExecuteDeployment/ExecuteDeploymentStream/SubmitDeploymentJob
-//                         and RollbackDeployment (re-validation at execution time)
+//                         (re-validation at execution time); malformed
+//                         RollbackDeployment input (e.g., missing deployment_id)
 //   PERMISSION_DENIED   — authorization or policy failures
 //   NOT_FOUND           — unknown deployment, revision, target, or job references
+//                         (RollbackDeployment returns NOT_FOUND for unknown
+//                         deployment_id or target_revision)
 //   RESOURCE_EXHAUSTED  — quota or rate-limit exceeded
-//   FAILED_PRECONDITION — job not in expected state for the requested operation
+//   FAILED_PRECONDITION — job not in expected state for the requested operation;
+//                         for RollbackDeployment, deployment not in a state
+//                         that permits rollback
 //   INTERNAL            — unexpected server errors
 //
 // Note: ValidateDeployment and DryRunDeployment always return gRPC status OK

--- a/geospatial/v1/deployment_service.proto
+++ b/geospatial/v1/deployment_service.proto
@@ -39,13 +39,18 @@ import "geospatial/v1/packaging_types.proto";
 // validation fails. They do not use INVALID_ARGUMENT for spec issues.
 //
 // Execution-phase failures (after execution begins) are returned with gRPC
-// status OK: unary RPCs populate the response error field; streaming RPCs
-// send a terminal error event. This ensures the structured ErrorDetail is
-// always available to the client. DEADLINE_EXCEEDED and CANCELLED may still
-// arrive as gRPC-level codes from client deadlines or transport cancellation.
+// status OK for execution RPCs: unary execution RPCs populate the response
+// error field; the execution stream (ExecuteDeploymentStream) sends a
+// terminal error event. This ensures the structured ErrorDetail is always
+// available to the client for execution flows. DEADLINE_EXCEEDED and
+// CANCELLED may still arrive as gRPC-level codes from client deadlines or
+// transport cancellation.
 //
-// StreamDeploymentHealth is long-lived by design. Servers MAY terminate the
-// stream with DEADLINE_EXCEEDED after a documented idle window; clients are
+// StreamDeploymentHealth is a long-lived telemetry stream, not an execution
+// stream, and is exempt from the in-band terminal-error contract above.
+// DeploymentHealthEvent carries observed health only; terminal failures
+// surface as non-OK gRPC status codes. Servers MAY terminate the stream
+// with DEADLINE_EXCEEDED after a documented idle window, and clients are
 // expected to reconnect to resume telemetry.
 service DeploymentService {
   // ValidateDeployment checks a deployment spec for structural and capability issues.

--- a/geospatial/v1/execution_types.proto
+++ b/geospatial/v1/execution_types.proto
@@ -8,7 +8,8 @@ package geospatial.v1;
 import "geospatial/v1/common.proto";
 import "geospatial/v1/spatial_types.proto";
 
-// Shared types for operator execution contracts across process and pipeline services.
+// Shared types for operator execution contracts across ProcessService,
+// PipelineService, RenderService, BuilderService, and DeploymentService.
 
 // WorkflowFamily identifies the category of operator workflow.
 // Values are scoped to families with a defined owning service in this package.
@@ -118,7 +119,9 @@ message ErrorDetail {
   string message = 3;
   // Descriptive label for the execution phase where the error occurred.
   string phase = 4;
-  // Correlates to PlanStep.step_id (ProcessService) or PipelineStage.stage_id (PipelineService).
+  // Correlates to the originating node: PlanStep.step_id (ProcessService),
+  // PipelineStage.stage_id (PipelineService), or a server-chosen stage
+  // identifier (RenderService, BuilderService, DeploymentService).
   string node_id = 5;
   Retryability retryability = 6;
   string suggested_action = 7;
@@ -169,7 +172,9 @@ message JobProgress {
   string job_id = 1;
   JobState state = 2;
   int32 progress_percent = 3;
-  // Correlates to PlanStep.step_id (ProcessService) or PipelineStage.stage_id (PipelineService).
+  // Correlates to the originating node: PlanStep.step_id (ProcessService),
+  // PipelineStage.stage_id (PipelineService), or a server-chosen stage
+  // identifier (RenderService, BuilderService, DeploymentService).
   string current_node_id = 4;
   int64 started_at = 5; // UTC milliseconds since epoch
   int64 updated_at = 6; // UTC milliseconds since epoch
@@ -178,7 +183,9 @@ message JobProgress {
 
 // StageResult reports the outcome of an individual execution stage.
 message StageResult {
-  // Correlates to PlanStep.step_id (ProcessService) or PipelineStage.stage_id (PipelineService).
+  // Correlates to the originating node: PlanStep.step_id (ProcessService),
+  // PipelineStage.stage_id (PipelineService), or a server-chosen stage
+  // identifier (RenderService, BuilderService, DeploymentService).
   string node_id = 1;
   StageState state = 2;
   ErrorDetail error = 3;
@@ -187,7 +194,9 @@ message StageResult {
 
 // PlanValidationIssue describes a problem found during plan or pipeline validation.
 message PlanValidationIssue {
-  // Correlates to PlanStep.step_id (ProcessService) or PipelineStage.stage_id (PipelineService).
+  // Correlates to the originating node: PlanStep.step_id (ProcessService),
+  // PipelineStage.stage_id (PipelineService), or a server-chosen stage
+  // identifier (RenderService, BuilderService, DeploymentService).
   string node_id = 1;
   string field = 2;
   string message = 3;

--- a/geospatial/v1/execution_types.proto
+++ b/geospatial/v1/execution_types.proto
@@ -12,11 +12,12 @@ import "geospatial/v1/spatial_types.proto";
 
 // WorkflowFamily identifies the category of operator workflow.
 // Values are scoped to families with a defined owning service in this package.
-// Values 2-4 are earmarked for publish, build, and deploy families and will
-// be defined when those services are added.
 enum WorkflowFamily {
   WORKFLOW_FAMILY_UNSPECIFIED = 0;
   WORKFLOW_FAMILY_ANALYZE = 1;
+  WORKFLOW_FAMILY_PUBLISH = 2;
+  WORKFLOW_FAMILY_BUILD = 3;
+  WORKFLOW_FAMILY_DEPLOY = 4;
 }
 
 // JobState represents the lifecycle state of an execution job.

--- a/geospatial/v1/packaging_types.proto
+++ b/geospatial/v1/packaging_types.proto
@@ -15,6 +15,14 @@ import "geospatial/v1/execution_types.proto";
 
 // MapPackage is a deterministic, MapLibre-compatible map composition that
 // downstream runtimes can hydrate without interpretation drift.
+//
+// Hydration readiness is guaranteed only when both map_artifact and
+// style_artifact are set. The one documented exception is preview-focused
+// results returned by RenderService when RenderSpec.preview_only is true:
+// only preview_artifact is guaranteed, map_artifact and style_artifact MAY
+// be empty, and such a package is not hydration-ready. Consumers that
+// hydrate a MapLibre runtime must either operate on non-preview MapPackages
+// or check that map_artifact and style_artifact are populated before use.
 message MapPackage {
   // Stable identifier for the package across revisions.
   string package_id = 1;

--- a/geospatial/v1/packaging_types.proto
+++ b/geospatial/v1/packaging_types.proto
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+import "geospatial/v1/common.proto";
+import "geospatial/v1/execution_types.proto";
+
+// Canonical packaging and deployment domain objects shared by RenderService,
+// BuilderService, and DeploymentService. These are shape contracts only:
+// artifact materialization (where bytes live, retention, immutability) is
+// owned by a later workspace/artifact contract.
+
+// MapPackage is a deterministic, MapLibre-compatible map composition that
+// downstream runtimes can hydrate without interpretation drift.
+message MapPackage {
+  // Stable identifier for the package across revisions.
+  string package_id = 1;
+  // MapPackage contract version (independent of the proto package version).
+  // Lets the shape co-evolve with consumer runtimes such as MapLibre SDKs.
+  string spec_version = 2;
+  // Primary packaged map bundle (sprites, glyphs, tile indexes).
+  ArtifactRef map_artifact = 3;
+  // MapLibre style JSON produced during render.
+  ArtifactRef style_artifact = 4;
+  // Optional raster or vector preview for console UIs.
+  ArtifactRef preview_artifact = 5;
+  // Canonical coordinate reference system for the map.
+  SpatialReference spatial_reference = 6;
+  // Map envelope.
+  Extent extent = 7;
+  // Upstream dataset references for provenance lookups.
+  repeated string source_refs = 8;
+  // Free-form display metadata (title, description, attribution).
+  map<string, string> metadata = 9;
+  // Workspace handle. Consistent with ArtifactRef.workspace_ref.
+  string workspace_ref = 10;
+}
+
+// AppPackage is a deterministic application bundle that can be deployed or
+// previewed.
+message AppPackage {
+  // Stable identifier for the package across revisions.
+  string package_id = 1;
+  // AppPackage contract version.
+  string spec_version = 2;
+  // Built static bundle.
+  ArtifactRef bundle_artifact = 3;
+  // Typed manifest (routes, entry points, capabilities).
+  ArtifactRef manifest_artifact = 4;
+  // References to MapPackage identifiers embedded in the app.
+  repeated string map_package_refs = 5;
+  // Typed runtime configuration (feature flags, env bindings).
+  ParameterMap runtime_config = 6;
+  // Free-form display metadata (title, description, icons).
+  map<string, string> metadata = 7;
+  // Workspace handle. Consistent with ArtifactRef.workspace_ref.
+  string workspace_ref = 8;
+}
+
+// DeploymentStrategy describes how an update rolls out to live targets.
+enum DeploymentStrategy {
+  DEPLOYMENT_STRATEGY_UNSPECIFIED = 0;
+  DEPLOYMENT_STRATEGY_IMMEDIATE = 1;
+  DEPLOYMENT_STRATEGY_BLUE_GREEN = 2;
+  DEPLOYMENT_STRATEGY_CANARY = 3;
+  DEPLOYMENT_STRATEGY_ROLLING = 4;
+}
+
+// DeploymentHealthStatus classifies the observed health of a deployment.
+enum DeploymentHealthStatus {
+  DEPLOYMENT_HEALTH_STATUS_UNSPECIFIED = 0;
+  DEPLOYMENT_HEALTH_STATUS_HEALTHY = 1;
+  DEPLOYMENT_HEALTH_STATUS_DEGRADED = 2;
+  DEPLOYMENT_HEALTH_STATUS_UNHEALTHY = 3;
+  DEPLOYMENT_HEALTH_STATUS_UNKNOWN = 4;
+}
+
+// DeploymentTarget identifies a logical deployment destination.
+// Cloud backend specifics are intentionally kept out of this contract.
+message DeploymentTarget {
+  string target_id = 1;
+  string environment = 2; // e.g., production, staging
+  string region = 3;
+  map<string, string> properties = 4;
+}
+
+// HealthCheck describes a probe evaluated after a deployment is promoted.
+message HealthCheck {
+  string name = 1;
+  string probe_type = 2; // e.g., http, grpc, tcp
+  string locator = 3; // URL or endpoint reference
+  int32 timeout_seconds = 4;
+  int32 success_threshold = 5;
+}
+
+// HealthCheckResult reports the observed outcome of a named probe.
+message HealthCheckResult {
+  string name = 1;
+  DeploymentHealthStatus status = 2;
+  string message = 3;
+  int64 observed_at = 4; // UTC milliseconds since epoch
+}
+
+// RollbackPolicy describes when a deployment should be rolled back automatically.
+message RollbackPolicy {
+  bool auto_rollback_on_failure = 1;
+  int32 failure_threshold = 2;
+}
+
+// DeploymentEndpoint describes a live endpoint exposed by a deployment.
+message DeploymentEndpoint {
+  string name = 1;
+  string url = 2;
+  string protocol = 3; // e.g., https, grpc
+  DeploymentHealthStatus health = 4;
+}
+
+// DeploymentSpec captures the desired state of a running deployment.
+message DeploymentSpec {
+  // Stable identifier for the deployment across revisions.
+  string deployment_id = 1;
+  // DeploymentSpec contract version.
+  string spec_version = 2;
+  // Package under deployment. ArtifactRef branch handles service definitions
+  // and other deployable artifact classes (e.g., SERVICE_DEFINITION).
+  oneof package_ref {
+    AppPackage app_package = 3;
+    MapPackage map_package = 4;
+    ArtifactRef artifact = 5;
+  }
+  DeploymentTarget target = 6;
+  DeploymentStrategy strategy = 7;
+  repeated HealthCheck health_checks = 8;
+  RollbackPolicy rollback_policy = 9;
+  // Workspace handle. Consistent with ArtifactRef.workspace_ref.
+  string workspace_ref = 10;
+}

--- a/geospatial/v1/render_service.proto
+++ b/geospatial/v1/render_service.proto
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+import "geospatial/v1/common.proto";
+import "geospatial/v1/execution_types.proto";
+import "geospatial/v1/packaging_types.proto";
+
+// RenderService provides typed RPC access to map composition and packaging.
+//
+// This service covers the execution lifecycle for rendering workflows:
+// render validation, dry-run estimation, synchronous and streaming execution,
+// and job management. Rendering produces a MapPackage — a deterministic,
+// MapLibre-compatible map composition — suitable for promotion into an
+// AppPackage or a direct Deployment.
+//
+// Transport-neutral status mapping for server implementations:
+//
+// Request-phase failures (returned as non-OK gRPC status, no response body):
+//   INVALID_ARGUMENT    — malformed requests or invalid render specs on
+//                         ExecuteRender/ExecuteRenderStream/SubmitRenderJob
+//                         (re-validation at execution time)
+//   PERMISSION_DENIED   — authorization or policy failures
+//   NOT_FOUND           — unknown source, style, or job references
+//   RESOURCE_EXHAUSTED  — quota or rate-limit exceeded
+//   FAILED_PRECONDITION — job not in expected state for the requested operation
+//   INTERNAL            — unexpected server errors
+//
+// Note: ValidateRender and DryRunRender always return gRPC status OK with a
+// structured response containing valid=false and populated issues when
+// validation fails. They do not use INVALID_ARGUMENT for spec issues.
+//
+// Execution-phase failures (after execution begins) are returned with gRPC
+// status OK: unary RPCs populate the response error field; streaming RPCs
+// send a terminal error event. This ensures the structured ErrorDetail is
+// always available to the client. DEADLINE_EXCEEDED and CANCELLED may still
+// arrive as gRPC-level codes from client deadlines or transport cancellation.
+service RenderService {
+  // ValidateRender checks a render spec for structural and capability issues.
+  rpc ValidateRender(ValidateRenderRequest) returns (ValidateRenderResponse);
+
+  // DryRunRender estimates the cost and impact of executing a render without side effects.
+  rpc DryRunRender(DryRunRenderRequest) returns (DryRunRenderResponse);
+
+  // ExecuteRender runs a render synchronously and returns the result.
+  rpc ExecuteRender(ExecuteRenderRequest) returns (ExecuteRenderResponse);
+
+  // ExecuteRenderStream runs a render and streams progress events and the final result.
+  rpc ExecuteRenderStream(ExecuteRenderRequest) returns (stream RenderEvent);
+
+  // SubmitRenderJob submits a render spec for asynchronous execution and returns a job handle.
+  rpc SubmitRenderJob(SubmitRenderJobRequest) returns (SubmitRenderJobResponse);
+
+  // GetRenderJob retrieves the current state and progress of a render job.
+  rpc GetRenderJob(GetRenderJobRequest) returns (GetRenderJobResponse);
+
+  // GetRenderJobResult retrieves the results of a completed render job.
+  rpc GetRenderJobResult(GetRenderJobResultRequest) returns (GetRenderJobResultResponse);
+
+  // CancelRenderJob requests cancellation of a running or pending render job.
+  rpc CancelRenderJob(CancelRenderJobRequest) returns (CancelRenderJobResponse);
+}
+
+// LayerSourceKind enumerates the source types that may back a render layer.
+enum LayerSourceKind {
+  LAYER_SOURCE_KIND_UNSPECIFIED = 0;
+  LAYER_SOURCE_KIND_FEATURE_SERVICE = 1;
+  LAYER_SOURCE_KIND_MAP_SERVICE = 2;
+  LAYER_SOURCE_KIND_VECTOR_TILE = 3;
+  LAYER_SOURCE_KIND_RASTER_TILE = 4;
+  LAYER_SOURCE_KIND_ARTIFACT = 5;
+}
+
+// LayerBinding describes a layer to include in the rendered map.
+// Typed filters and style overrides use ParameterValue for type safety with
+// the same typed-branch convention as PlanStep inputs.
+message LayerBinding {
+  string layer_id = 1;
+  LayerSourceKind source_kind = 2;
+  // Dataset locator, feature service reference, or ArtifactRef.artifact_id.
+  string source_ref = 3;
+  // Typed filter (e.g., spatial_filter_value, ParameterMap for attribute filters).
+  ParameterValue filter = 4;
+  // Typed style overrides (MapLibre layer-level hints).
+  ParameterMap style_overrides = 5;
+}
+
+// RenderSpec describes a map composition request.
+message RenderSpec {
+  string render_id = 1;
+  // RenderSpec contract version.
+  string spec_version = 2;
+  // Workflow family. Rendering uses WORKFLOW_FAMILY_PUBLISH; other values are
+  // reserved for forward compatibility.
+  WorkflowFamily workflow_family = 3;
+  // MapLibre style hints and overrides (title, basemap, palette, theme).
+  ParameterMap style_spec = 4;
+  repeated LayerBinding layer_bindings = 5;
+  // If true, only a preview artifact is produced and MapPackage packaging is skipped.
+  bool preview_only = 6;
+  // Canonical CRS for the output map.
+  SpatialReference target_spatial_reference = 7;
+  // Optional clipping envelope for the output map.
+  Extent target_extent = 8;
+  // Free-form display metadata carried into the produced MapPackage.
+  map<string, string> metadata = 9;
+}
+
+// ValidateRenderRequest asks the server to check a render spec.
+message ValidateRenderRequest {
+  RenderSpec spec = 1;
+}
+
+// ValidateRenderResponse returns the validation outcome.
+message ValidateRenderResponse {
+  bool valid = 1;
+  repeated PlanValidationIssue issues = 2;
+}
+
+// DryRunRenderRequest asks the server to estimate render execution impact.
+message DryRunRenderRequest {
+  RenderSpec spec = 1;
+}
+
+// DryRunRenderResponse contains the validation outcome and dry-run estimation.
+message DryRunRenderResponse {
+  bool valid = 1;
+  repeated PlanValidationIssue issues = 2;
+  DryRunResult result = 3;
+}
+
+// ExecuteRenderRequest submits a render for synchronous or streaming execution.
+message ExecuteRenderRequest {
+  RenderSpec spec = 1;
+  ExecutionContext context = 2;
+}
+
+// ExecuteRenderResponse returns the complete result of synchronous execution.
+// The gRPC status is OK regardless of execution outcome. On success, only
+// result is populated; on terminal failure, only error is populated.
+message ExecuteRenderResponse {
+  string job_id = 1;
+  oneof outcome {
+    RenderResult result = 2;
+    ErrorDetail error = 3;
+  }
+}
+
+// RenderEvent is a streaming message carrying progress, stage, result, or error events.
+message RenderEvent {
+  oneof event {
+    JobProgress progress = 1;
+    StageResult stage_result = 2;
+    RenderResult result = 3;
+    ErrorDetail error = 4;
+  }
+}
+
+// RenderResult contains the output of a completed render execution.
+message RenderResult {
+  string result_id = 1;
+  JobState status = 2;
+  string summary = 3;
+  repeated Assumption assumptions = 4;
+  // Produced MapPackage. When RenderSpec.preview_only is true, map_package may
+  // be unset and preview_artifact is populated on the MapPackage instead.
+  MapPackage map_package = 5;
+  repeated ArtifactRef artifacts = 6;
+  repeated StageResult stage_results = 7;
+  ProvenanceRecord provenance = 8;
+}
+
+// SubmitRenderJobRequest submits a render spec for asynchronous execution.
+message SubmitRenderJobRequest {
+  RenderSpec spec = 1;
+  ExecutionContext context = 2;
+}
+
+// SubmitRenderJobResponse confirms render job submission.
+message SubmitRenderJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+}
+
+// GetRenderJobRequest retrieves the current state of a render job.
+message GetRenderJobRequest {
+  string job_id = 1;
+}
+
+// GetRenderJobResponse returns the render job state and progress.
+message GetRenderJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+  JobProgress progress = 3;
+}
+
+// GetRenderJobResultRequest retrieves the results of a completed render job.
+message GetRenderJobResultRequest {
+  string job_id = 1;
+}
+
+// GetRenderJobResultResponse returns the render job result.
+// The gRPC status is OK regardless of job outcome. For failed jobs, the
+// error field carries the structured ErrorDetail.
+message GetRenderJobResultResponse {
+  string job_id = 1;
+  oneof outcome {
+    RenderResult result = 2;
+    ErrorDetail error = 3;
+  }
+}
+
+// CancelRenderJobRequest requests cancellation of a render job.
+message CancelRenderJobRequest {
+  string job_id = 1;
+}
+
+// CancelRenderJobResponse confirms the render cancellation outcome.
+message CancelRenderJobResponse {
+  string job_id = 1;
+  JobState state = 2;
+}

--- a/geospatial/v1/render_service.proto
+++ b/geospatial/v1/render_service.proto
@@ -99,7 +99,9 @@ message RenderSpec {
   // MapLibre style hints and overrides (title, basemap, palette, theme).
   ParameterMap style_spec = 4;
   repeated LayerBinding layer_bindings = 5;
-  // If true, only a preview artifact is produced and MapPackage packaging is skipped.
+  // If true, the server produces a preview-focused MapPackage: map_package is
+  // still populated on RenderResult, but only preview_artifact is guaranteed
+  // to be set; map_artifact and style_artifact MAY be omitted.
   bool preview_only = 6;
   // Canonical CRS for the output map.
   SpatialReference target_spatial_reference = 7;
@@ -165,8 +167,9 @@ message RenderResult {
   JobState status = 2;
   string summary = 3;
   repeated Assumption assumptions = 4;
-  // Produced MapPackage. When RenderSpec.preview_only is true, map_package may
-  // be unset and preview_artifact is populated on the MapPackage instead.
+  // Produced MapPackage. Always populated on successful execution. When
+  // RenderSpec.preview_only is true, only preview_artifact is guaranteed to
+  // be set; the packaged outputs (map_artifact, style_artifact) MAY be empty.
   MapPackage map_package = 5;
   repeated ArtifactRef artifacts = 6;
   repeated StageResult stage_results = 7;

--- a/geospatial/v1/render_service.proto
+++ b/geospatial/v1/render_service.proto
@@ -13,9 +13,12 @@ import "geospatial/v1/packaging_types.proto";
 //
 // This service covers the execution lifecycle for rendering workflows:
 // render validation, dry-run estimation, synchronous and streaming execution,
-// and job management. Rendering produces a MapPackage — a deterministic,
-// MapLibre-compatible map composition — suitable for promotion into an
-// AppPackage or a direct Deployment.
+// and job management. A non-preview render produces a hydration-ready
+// MapPackage — a deterministic, MapLibre-compatible map composition —
+// suitable for promotion into an AppPackage or a direct Deployment. A
+// preview-only render (RenderSpec.preview_only = true) returns a
+// preview-focused MapPackage that carries only preview_artifact; such a
+// result is not hydration-ready and is intended for console/UI previews.
 //
 // Transport-neutral status mapping for server implementations:
 //
@@ -99,9 +102,11 @@ message RenderSpec {
   // MapLibre style hints and overrides (title, basemap, palette, theme).
   ParameterMap style_spec = 4;
   repeated LayerBinding layer_bindings = 5;
-  // If true, the server produces a preview-focused MapPackage: map_package is
-  // still populated on RenderResult, but only preview_artifact is guaranteed
-  // to be set; map_artifact and style_artifact MAY be omitted.
+  // If true, the server produces a preview-focused MapPackage intended for
+  // console/UI previews only. map_package is still populated on RenderResult,
+  // but only preview_artifact is guaranteed to be set; map_artifact and
+  // style_artifact MAY be omitted, and the returned MapPackage is not
+  // hydration-ready (see MapPackage comment in packaging_types.proto).
   bool preview_only = 6;
   // Canonical CRS for the output map.
   SpatialReference target_spatial_reference = 7;
@@ -167,9 +172,12 @@ message RenderResult {
   JobState status = 2;
   string summary = 3;
   repeated Assumption assumptions = 4;
-  // Produced MapPackage. Always populated on successful execution. When
-  // RenderSpec.preview_only is true, only preview_artifact is guaranteed to
-  // be set; the packaged outputs (map_artifact, style_artifact) MAY be empty.
+  // Produced MapPackage. Always populated on successful execution. For
+  // non-preview renders, the MapPackage is hydration-ready (map_artifact and
+  // style_artifact are set). When RenderSpec.preview_only is true, only
+  // preview_artifact is guaranteed to be set; the packaged outputs
+  // (map_artifact, style_artifact) MAY be empty and the MapPackage is not
+  // hydration-ready.
   MapPackage map_package = 5;
   repeated ArtifactRef artifacts = 6;
   repeated StageResult stage_results = 7;


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #7
## Summary

- All five execution services still share the terminal in-band `ErrorDetail` contract for execution RPCs (`Execute*` / `Execute*Stream` / `Get*JobResult` / `Rollback*`); verified unchanged in `process_service.proto`, `pipeline_service.proto`, `render_service.proto`, `builder_service.proto`, and the execution surfaces of `deployment_service.proto`.
- Canonical message shapes, `workspace_ref` on `DeploymentSpec`, `WorkflowFamily` slots, and the hydration-ready `MapPackage` contract are unchanged.
## Changes Made

- All five execution services still share the terminal in-band `ErrorDetail` contract for execution RPCs (`Execute*` / `Execute*Stream` / `Get*JobResult` / `Rollback*`); verified unchanged in `process_service.proto`, `pipeline_service.proto`, `render_service.proto`, `builder_service.proto`, and the execution surfaces of `deployment_service.proto`.
- Canonical message shapes, `workspace_ref` on `DeploymentSpec`, `WorkflowFamily` slots, and the hydration-ready `MapPackage` contract are unchanged.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
- **Chose suggested-fix option B (narrow the contract) over option A (wrap `DeploymentHealthEvent` in an envelope).** Health telemetry is inherently reconnect-driven, not terminal — an in-band error envelope would be dead surface area for a stream whose failure mode is the gRPC `DEADLINE_EXCEEDED` reconnect loop the spec already documents. Option B is the lower-churn change and aligns with the existing `docs/specification.md:505`, `:613`, and `:622` passages that already scope terminal-error semantics to execution streams.
- **Bounded sibling sweep for the invariant class "streaming RPCs use in-band terminal `ErrorDetail`":**
  - `process_service.proto` (`ExecutePlanStream` → `ExecutionEvent.error`): compliant.
  - `pipeline_service.proto` (`ExecutePipelineStream` → `PipelineEvent.error`): compliant.
  - `render_service.proto` (`ExecuteRenderStream` → `RenderEvent.error`): compliant.
  - `builder_service.proto` (`ExecuteBuildStream` → `BuildEvent.error`): compliant.
  - `deployment_service.proto` (`ExecuteDeploymentStream` → `DeploymentEvent.error`): compliant.
  - `feature_service.proto` (`QueryFeaturesStream` → `FeaturePage`): pagination stream, does not claim the contract — out of scope.
  - `form_service.proto` (`StreamFormUpdates` bidi): collaborative editing stream, does not claim the contract — out of scope.
  - Only `StreamDeploymentHealth` was the outlier; no sibling surface found with the same invariant mismatch.
- Left `examples/*/README.md` working-tree modifications untouched — they are from a prior docs pass, not from this finding.

Follow-ons:
- None tied to the current finding set.

Code kaizen:
Skipped by kaizen policy.
