### PR TITLE
[codex] publish Geospatial.Grpc package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   BUF_VERSION: "1.66.0"
+  DOTNET_VERSION: "10.0.x"
 
 jobs:
   lint-and-validate:
@@ -91,6 +92,9 @@ jobs:
     needs: [lint-and-validate, generate]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout Code
@@ -166,15 +170,44 @@ jobs:
           path: descriptors/
           retention-days: 90
 
+  dotnet-package:
+    name: Pack .NET Protocol Package
+    runs-on: ubuntu-latest
+    needs: lint-and-validate
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Pack Geospatial.Grpc
+        run: |
+          dotnet pack src/Geospatial.Grpc/Geospatial.Grpc.csproj \
+            --configuration Release \
+            -o nupkgs \
+            /p:TreatWarningsAsErrors=true
+
+      - name: Upload .NET package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: geospatial-grpc-dotnet-package
+          path: nupkgs/
+          retention-days: 30
+
   notify:
     name: Notify Success
     runs-on: ubuntu-latest
-    needs: [lint-and-validate, generate, validate-schemas, publish]
+    needs: [lint-and-validate, generate, validate-schemas, dotnet-package, publish]
     if: |
       always() &&
       needs.lint-and-validate.result == 'success' &&
       needs.generate.result == 'success' &&
       needs.validate-schemas.result == 'success' &&
+      needs.dotnet-package.result == 'success' &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
 
     steps:
@@ -184,6 +217,7 @@ jobs:
           echo "  - Protobuf files validated and formatted"
           echo "  - Multi-language code generation verified"
           echo "  - Schema descriptors exported"
+          echo "  - .NET protocol package packed"
           if [[ "${{ needs.publish.result }}" == "success" ]]; then
             echo "  - Published to Buf Registry"
           elif [[ "${{ needs.publish.result }}" == "skipped" ]]; then

--- a/.github/workflows/publish-dotnet-protocol.yml
+++ b/.github/workflows/publish-dotnet-protocol.yml
@@ -1,0 +1,161 @@
+name: Publish .NET Protocol Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run validation only (skip publish)"
+        required: false
+        default: true
+        type: boolean
+  push:
+    tags:
+      - "geospatial-grpc-v*"
+
+env:
+  DOTNET_VERSION: "10.0.x"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  package-smoke:
+    name: Package Smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Validate package version
+        shell: bash
+        run: |
+          package_version="$(dotnet msbuild src/Geospatial.Grpc/Geospatial.Grpc.csproj -nologo -getProperty:PackageVersion)"
+          if [[ -z "${package_version}" ]]; then
+            package_version="$(dotnet msbuild src/Geospatial.Grpc/Geospatial.Grpc.csproj -nologo -getProperty:Version)"
+          fi
+
+          if [[ -z "${package_version}" ]]; then
+            echo "Could not resolve Geospatial.Grpc package version."
+            exit 1
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            tag_version="${GITHUB_REF_NAME#geospatial-grpc-v}"
+            if [[ "${tag_version}" != "${package_version}" ]]; then
+              echo "Tag version (${tag_version}) does not match package version (${package_version})."
+              exit 1
+            fi
+          fi
+
+          echo "PACKAGE_VERSION=${package_version}" >> "${GITHUB_ENV}"
+
+      - name: Pack Geospatial.Grpc
+        run: |
+          mkdir -p nupkgs
+          dotnet pack src/Geospatial.Grpc/Geospatial.Grpc.csproj \
+            --configuration Release \
+            -o nupkgs \
+            /p:TreatWarningsAsErrors=true
+
+      - name: Package install smoke
+        shell: bash
+        run: |
+          smoke_dir="$(mktemp -d)"
+          trap 'rm -rf "${smoke_dir}"' EXIT
+
+          dotnet new console --framework net10.0 --output "${smoke_dir}"
+
+          pushd "${smoke_dir}" >/dev/null
+
+          cat > NuGet.config <<EOF
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local-geospatial" value="${GITHUB_WORKSPACE}/nupkgs" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+            </packageSources>
+            <packageSourceMapping>
+              <packageSource key="local-geospatial">
+                <package pattern="Geospatial.Grpc" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          EOF
+
+          dotnet add package Grpc.Net.Client --version 2.76.0
+          dotnet add package Geospatial.Grpc --version "${PACKAGE_VERSION}"
+
+          cat > Program.cs <<'EOF'
+          using Geospatial.V1;
+          using Grpc.Net.Client;
+
+          using var channel = GrpcChannel.ForAddress("https://example.invalid");
+
+          _ = new FeatureService.FeatureServiceClient(channel);
+          _ = new FormService.FormServiceClient(channel);
+          _ = new ProcessService.ProcessServiceClient(channel);
+          _ = new SpecService.SpecServiceClient(channel);
+          _ = new QueryFeaturesRequest
+          {
+              ServiceId = "parks",
+              LayerId = 0,
+              ReturnGeometry = true,
+              OutSr = new SpatialReference { Wkid = 4326 }
+          };
+          EOF
+
+          dotnet build --configuration Release /p:TreatWarningsAsErrors=true
+
+          popd >/dev/null
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: geospatial-grpc-dotnet-${{ github.run_id }}-packages
+          path: nupkgs/*.nupkg
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Dry-run summary
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
+        shell: bash
+        run: |
+          echo "Dry run complete. Built packages:" >> "${GITHUB_STEP_SUMMARY}"
+          ls -1 nupkgs/*.nupkg >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    name: Publish to GitHub Packages
+    needs: package-smoke
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: geospatial-grpc-dotnet-${{ github.run_id }}-packages
+          path: nupkgs
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Publish to GitHub Packages
+        run: |
+          dotnet nuget push nupkgs/*.nupkg \
+            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            --api-key "${{ secrets.GITHUB_TOKEN }}" \
+            --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The **Geospatial gRPC Standard** aims to democratize geospatial development by p
 | `RenderService` | Map composition and packaging | Render validation, dry-run, streaming execution, produces `MapPackage` |
 | `BuilderService` | Application bundle synthesis | Build validation, dry-run, streaming execution, produces `AppPackage` |
 | `DeploymentService` | Deployment promotion and lifecycle | Validation, dry-run, streaming execution, rollback, health telemetry |
+| `SpecService` | Spec plan/apply workflows | Plan canonical specs, stream apply progress, cancel apply |
 
 ### Key Message Types
 
@@ -75,7 +76,8 @@ ls geospatial/v1/
 # ├── pipeline_service.proto            # Data publishing pipelines
 # ├── render_service.proto              # Map composition and packaging
 # ├── builder_service.proto             # Application bundle synthesis
-# └── deployment_service.proto          # Deployment promotion and lifecycle
+# ├── deployment_service.proto          # Deployment promotion and lifecycle
+# └── spec_service.proto                # Spec plan/apply workflows
 ```
 
 ### 2. Generate Client Libraries
@@ -96,6 +98,19 @@ ls gen/
 # ├── typescript/ # TypeScript/JavaScript
 # └── ...
 ```
+
+### .NET Protocol Package
+
+The repository also includes a generated .NET protocol package project:
+
+```bash
+dotnet pack src/Geospatial.Grpc/Geospatial.Grpc.csproj --configuration Release -o ./nupkgs
+```
+
+Downstream .NET clients should reference a published `Geospatial.Grpc` package
+instead of copying `.proto` files into application or SDK repositories.
+The `Publish .NET Protocol Package` workflow publishes `Geospatial.Grpc` to
+GitHub Packages from `geospatial-grpc-v*` tags or manual non-dry-run dispatches.
 
 ### 3. Use in Your Project
 
@@ -167,6 +182,7 @@ for feature in response.features:
 ## 📚 Documentation
 
 - **[Protocol Specification](docs/specification.md)** - Detailed protocol documentation
+- **[Protocol Ownership](docs/proto-ownership.md)** - Canonical proto ownership and downstream sync rules
 - **[Getting Started Guide](docs/getting-started.md)** - Developer quick start
 - **[Versioning Policy](VERSIONING.md)** - Compatibility guarantees and change governance
 - **[Examples](examples/)** - Code samples for multiple languages
@@ -189,7 +205,9 @@ geospatial-grpc/
 │   ├── pipeline_service.proto            # Data publishing pipelines
 │   ├── render_service.proto              # Map composition and packaging
 │   ├── builder_service.proto             # Application bundle synthesis
-│   └── deployment_service.proto          # Deployment promotion and lifecycle
+│   ├── deployment_service.proto          # Deployment promotion and lifecycle
+│   └── spec_service.proto                # Spec plan/apply workflows
+├── src/Geospatial.Grpc/        # .NET protocol package project
 ├── docs/                       # Protocol documentation
 ├── examples/                   # Language-specific examples
 ├── gen/                        # Generated client libraries

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,7 +1,7 @@
 version: v1
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - ENUM_VALUE_PREFIX
     - ENUM_ZERO_VALUE_SUFFIX

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,11 +80,12 @@ cd GeospatialGrpcExample
 2. **Add gRPC packages**:
 ```bash
 dotnet add package Grpc.Net.Client
-dotnet add package Google.Protobuf
-dotnet add package Grpc.Tools
+dotnet add package Geospatial.Grpc --prerelease
 ```
 
-3. **Copy generated files**:
+If a published `Geospatial.Grpc` package is not available yet, generate the
+bindings locally and copy them into the example project:
+
 ```bash
 cp -r ../gen/csharp/* .
 ```

--- a/docs/proto-ownership.md
+++ b/docs/proto-ownership.md
@@ -1,0 +1,77 @@
+# Protocol Ownership and Downstream Sync
+
+This repository is the canonical home for shared geospatial gRPC protocol
+definitions. Honua servers, SDKs, mobile apps, and admin tools may generate,
+package, or pin client code from these definitions, but local copies in those
+repositories are not the source of truth.
+
+## Canonical Layout
+
+- Protocol definitions live under `geospatial/v1/`.
+- The protocol package is `geospatial.v1` for the current major version.
+- Shared geometry, field, and attribute contracts belong in this repository
+  when they are used by more than one Honua runtime.
+- Service contracts that are Honua-specific but shared across repos should be
+  proposed here first, then consumed downstream after review.
+- Repo-specific implementation types, adapters, persistence models, and UI
+  models should stay in their owning application repository.
+
+## Change Rules
+
+Protocol changes must start in this repository before downstream repositories
+update generated clients or compatibility adapters.
+
+1. Open or update a tracking issue that explains the downstream consumers.
+2. Update the `.proto` files under `geospatial/v1/`.
+3. Run `buf format --diff --exit-code`, `buf lint`, and `buf breaking`.
+4. Update protocol docs and examples when behavior changes.
+5. Publish or pin the generated artifacts used by downstream consumers.
+6. Update downstream repos to consume the reviewed protocol revision.
+
+Breaking changes require a new package/version path, such as `geospatial/v2`,
+unless every affected consumer has an explicit migration plan.
+
+## Compatibility Rules
+
+- Prefer additive fields, messages, methods, and enum values.
+- Do not reuse field numbers.
+- Reserve field numbers and names when removing fields.
+- Do not rename fields, messages, services, or enum values in `geospatial.v1`.
+- Keep default values meaningful for older clients.
+- Document server feature flags or optional behavior in the service comments and
+  generated docs.
+
+## Honua Consumer Contract
+
+| Repo | Role | Protocol rule |
+| --- | --- | --- |
+| `honua-server` | Implements gRPC services | Must implement the canonical schemas from this repository. Server-local protos are temporary migration inputs only. |
+| `honua-sdk-dotnet` | Publishes .NET SDK clients and domain abstractions | Must consume generated protocol clients through package references or generated artifacts derived from this repository. It should not own independent `.proto` definitions. |
+| `honua-mobile` | Uses SDK capabilities in mobile workflows | Should consume protocol behavior through the .NET SDK packages instead of duplicating transport clients. |
+| `honua-server-admin` | Uses admin/server APIs | Should consume SDK packages for shared admin clients and generated protocol contracts where applicable. |
+
+## Current Honua Reconciliation Items
+
+| Contract | Current status | Next action |
+| --- | --- | --- |
+| `feature_service.proto` | Exists here and in downstream copies with package/layout drift. | Sync downstream consumers to the canonical `geospatial/v1` contract. |
+| `form_service.proto` | Canonical contract now includes downstream workflow/action and access-control fields. | Sync downstream consumers to this file and remove editable local copies. |
+| `process_service.proto` | Canonical contract now lives here. | Sync `honua-server` generated bindings from this repository. |
+| `spec_service.proto` | Canonical contract now lives here. | Sync `honua-server` and SDK/admin spec clients from this repository. |
+
+Tracking issue: <https://github.com/honua-io/geospatial-grpc/issues/12>
+
+## Downstream Sync Checklist
+
+Use this checklist when updating a downstream repo after protocol changes land
+here.
+
+- Record the geospatial-grpc commit, Buf module digest, package version, or
+  generated artifact version being consumed.
+- Remove or mark any repo-local `.proto` snapshots as generated/pinned copies,
+  not editable source files.
+- Update generated clients or SDK package references. .NET consumers should use
+  the `Geospatial.Grpc` NuGet package when they need generated protocol
+  bindings.
+- Run downstream compile, analyzer, and protocol integration tests.
+- Link the downstream PR or issue back to the source protocol issue.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -4,6 +4,9 @@
 
 This specification defines standardized gRPC protocols for geospatial data access, mobile field data collection, process execution, data publishing pipelines, map rendering, application building, and deployment. The protocols provide type-safe, high-performance service contracts for spatial feature CRUD, mobile forms, analysis workflow execution, dataset publishing, packaged map composition, application bundle synthesis, and deployment promotion.
 
+Protocol ownership, compatibility, and downstream sync rules are maintained in
+[Protocol Ownership and Downstream Sync](proto-ownership.md).
+
 ## Design Principles
 
 ### 1. Type Safety
@@ -67,6 +70,7 @@ The `FormService` provides mobile data collection capabilities as a modern alter
 - **Rich Controls**: Location, media, validation, conditional logic
 - **Mobile Optimization**: Device-aware form rendering
 - **Real-time Collaboration**: Multi-user form editing
+- **Workflow and Access Control**: Lifecycle actions plus role/location rules
 
 #### Key Methods
 
@@ -151,6 +155,25 @@ Execution errors are returned as `ErrorDetail` messages with:
 - `retryability`: How to recover (fix plan, fix data, retry transient error, permanent failure)
 - `suggested_action`: Human-readable recovery guidance
 - `details`: Optional key-value map for additional machine-readable context
+
+### SpecService
+
+The `SpecService` provides Terraform-style plan/apply semantics for canonical
+geospatial spec documents:
+
+- **Plan**: Validate a spec and return the DAG, content hashes, and cost estimates without side effects
+- **Apply**: Execute the spec as a server-streaming workflow with per-node progress events
+- **Cancel**: Cooperatively cancel an in-flight apply run by apply token
+
+#### Key Methods
+
+```protobuf
+service SpecService {
+  rpc PlanSpec(PlanSpecRequest) returns (PlanSpecResponse);
+  rpc ApplySpec(ApplySpecRequest) returns (stream ApplySpecEvent);
+  rpc CancelApply(CancelApplyRequest) returns (CancelApplyResponse);
+}
+```
 
 ### PipelineService
 

--- a/geospatial/v1/form_service.proto
+++ b/geospatial/v1/form_service.proto
@@ -55,6 +55,8 @@ message FormDefinition {
   repeated FormBinding bindings = 8;
   FormLayout layout_hints = 9;
   repeated FormGroup groups = 10;
+  repeated WorkflowAction workflow_actions = 11;
+  FormAccessControl access_control = 12;
 }
 
 // FormControl represents individual form elements (gRPC equivalent of OpenRosa controls).
@@ -82,6 +84,15 @@ message FormControl {
 
   // Mobile-specific optimizations
   MobileControlHints mobile_hints = 20;
+
+  // Conditional visibility expression. When non-empty the control is only
+  // shown when the expression evaluates to true against current field values.
+  // Uses the same expression language as CalculatedValue.
+  string visibility_expression = 21;
+
+  // Conditional read-only expression. When non-empty the control becomes
+  // read-only when the expression evaluates to true.
+  string read_only_expression = 22;
 }
 
 // TextInputControl for single-line or multi-line text entry.
@@ -590,6 +601,59 @@ message FormCompatibility {
   repeated string supported_platforms = 2;
   bool requires_online = 3;
   repeated string required_permissions = 4;
+}
+
+// WorkflowAction defines an automated action triggered by a form lifecycle event.
+message WorkflowAction {
+  string action_id = 1;
+  WorkflowTrigger trigger = 2;
+  string condition_expression = 3; // Optional guard expression
+  WorkflowActionType action_type = 4;
+  map<string, string> parameters = 5; // Action-specific key/value parameters
+  int32 execution_order = 6; // Order when multiple actions share a trigger
+}
+
+enum WorkflowTrigger {
+  WORKFLOW_TRIGGER_UNSPECIFIED = 0;
+  WORKFLOW_TRIGGER_ON_LOAD = 1; // Form opened or loaded
+  WORKFLOW_TRIGGER_ON_SAVE = 2; // Draft saved
+  WORKFLOW_TRIGGER_ON_SUBMIT = 3; // Form submitted
+  WORKFLOW_TRIGGER_ON_APPROVE = 4; // Supervisor approval
+  WORKFLOW_TRIGGER_ON_REJECT = 5; // Supervisor rejection
+  WORKFLOW_TRIGGER_ON_FIELD_CHANGE = 6; // Specific field value changed
+}
+
+enum WorkflowActionType {
+  WORKFLOW_ACTION_TYPE_UNSPECIFIED = 0;
+  WORKFLOW_ACTION_TYPE_WEBHOOK = 1; // HTTP callback
+  WORKFLOW_ACTION_TYPE_SET_FIELD = 2; // Set a field value
+  WORKFLOW_ACTION_TYPE_SET_STATUS = 3; // Transition instance status
+  WORKFLOW_ACTION_TYPE_SEND_NOTIFICATION = 4; // Push or email notification
+  WORKFLOW_ACTION_TYPE_CREATE_FEATURE = 5; // Create a related feature
+  WORKFLOW_ACTION_TYPE_VALIDATE = 6; // Run additional validation
+}
+
+// FormAccessControl defines role- and location-based access to a form.
+message FormAccessControl {
+  // Roles allowed to open this form. Empty means unrestricted.
+  repeated string allowed_roles = 1;
+
+  // Roles allowed to approve or reject submissions.
+  repeated string approver_roles = 2;
+
+  // Optional geographic boundary where the form is available.
+  Extent location_boundary = 3;
+
+  // Per-field role overrides.
+  repeated FieldAccessRule field_access_rules = 4;
+}
+
+// FieldAccessRule restricts visibility or editability of a single field by role.
+message FieldAccessRule {
+  string field_id = 1;
+  repeated string visible_to_roles = 2; // Empty means visible to all allowed roles
+  repeated string editable_by_roles = 3; // Empty means editable by all allowed roles
+  bool read_only = 4; // Hard read-only regardless of role
 }
 
 // Validation request/response.

--- a/geospatial/v1/spec_service.proto
+++ b/geospatial/v1/spec_service.proto
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+// SpecService exposes Terraform-style plan/apply semantics for canonical
+// geospatial spec documents. Plan is side-effect-free and returns the DAG shape
+// plus per-node cost estimates. Apply is server-streaming and emits per-node
+// progress events.
+service SpecService {
+  // Plans a canonical spec document and returns the DAG, cost estimates, and
+  // any structured warnings.
+  rpc PlanSpec(PlanSpecRequest) returns (PlanSpecResponse);
+
+  // Applies a canonical spec document and streams per-node progress events.
+  // The stream completes when the apply reaches a terminal state.
+  rpc ApplySpec(ApplySpecRequest) returns (stream ApplySpecEvent);
+
+  // Cooperatively cancels an in-flight apply run by apply token.
+  rpc CancelApply(CancelApplyRequest) returns (CancelApplyResponse);
+}
+
+// Plan messages.
+
+message PlanSpecRequest {
+  CanonicalSpecDocument document = 1;
+}
+
+message PlanSpecResponse {
+  SpecPlan plan = 1;
+}
+
+// Apply messages.
+
+message ApplySpecRequest {
+  CanonicalSpecDocument document = 1;
+  SpecCacheMode cache_mode = 2;
+  uint32 max_concurrency = 3;
+}
+
+message ApplySpecEvent {
+  int64 sequence = 1;
+  SpecApplyEventKind kind = 2;
+  string apply_token = 3;
+  optional string node_id = 4;
+  optional string content_hash = 5;
+  int64 timestamp_unix_ms = 6;
+  optional SpecDiagnostic diagnostic = 7;
+  optional SpecCostActual actual_cost = 8;
+  optional SpecApplySummary summary = 9;
+}
+
+message CancelApplyRequest {
+  string apply_token = 1;
+}
+
+message CancelApplyResponse {
+  bool cancelled = 1;
+}
+
+// Domain messages.
+
+message CanonicalSpecDocument {
+  string grammar_version = 1;
+  string process_family_version = 2;
+  optional string spec_id = 3;
+  repeated CanonicalSpecNode nodes = 4;
+}
+
+message CanonicalSpecNode {
+  string id = 1;
+  SpecResourceKind kind = 2;
+  optional string op = 3;
+  map<string, string> inputs = 4;
+  map<string, string> parameters = 5;
+  optional string canonical_fragment = 6;
+  map<string, string> source_pins = 7;
+  bool nondeterministic = 8;
+}
+
+message SpecPlan {
+  string plan_id = 1;
+  string grammar_version = 2;
+  string process_family_version = 3;
+  repeated SpecPlanNode nodes = 4;
+  repeated SpecDiagnostic warnings = 5;
+}
+
+message SpecPlanNode {
+  string node_id = 1;
+  SpecResourceKind kind = 2;
+  optional string op = 3;
+  repeated string depends_on = 4;
+  string content_hash = 5;
+  SpecCostEstimate cost = 6;
+  repeated SpecDiagnostic warnings = 7;
+}
+
+message SpecCostEstimate {
+  optional int64 estimated_rows = 1;
+  optional int64 estimated_bytes = 2;
+  optional double estimated_duration_ms = 3;
+}
+
+message SpecCostActual {
+  optional int64 rows = 1;
+  optional int64 bytes = 2;
+  double duration_ms = 3;
+}
+
+message SpecApplySummary {
+  int32 total_nodes = 1;
+  int32 cached_nodes = 2;
+  int32 ran_nodes = 3;
+  int32 failed_nodes = 4;
+  int32 skipped_nodes = 5;
+  double total_duration_ms = 6;
+  bool cancelled = 7;
+}
+
+message SpecDiagnostic {
+  string code = 1;
+  string message = 2;
+  SpecDiagnosticSeverity severity = 3;
+  optional string node_id = 4;
+  optional string remedy = 5;
+}
+
+// Enums.
+
+enum SpecResourceKind {
+  SPEC_RESOURCE_KIND_UNSPECIFIED = 0;
+  SPEC_RESOURCE_KIND_COMPUTE = 1;
+  SPEC_RESOURCE_KIND_REPORT = 2;
+  SPEC_RESOURCE_KIND_DATASET = 3;
+  SPEC_RESOURCE_KIND_SERVICE = 4;
+  SPEC_RESOURCE_KIND_APP = 5;
+}
+
+enum SpecApplyEventKind {
+  SPEC_APPLY_EVENT_KIND_UNSPECIFIED = 0;
+  SPEC_APPLY_EVENT_KIND_QUEUED = 1;
+  SPEC_APPLY_EVENT_KIND_RUNNING = 2;
+  SPEC_APPLY_EVENT_KIND_CACHED = 3;
+  SPEC_APPLY_EVENT_KIND_SUCCEEDED = 4;
+  SPEC_APPLY_EVENT_KIND_FAILED = 5;
+  SPEC_APPLY_EVENT_KIND_SKIPPED = 6;
+  SPEC_APPLY_EVENT_KIND_WARNING = 7;
+  SPEC_APPLY_EVENT_KIND_APPLY_STARTED = 8;
+  SPEC_APPLY_EVENT_KIND_APPLY_COMPLETED = 9;
+  SPEC_APPLY_EVENT_KIND_APPLY_CANCELLED = 10;
+}
+
+enum SpecDiagnosticSeverity {
+  SPEC_DIAGNOSTIC_SEVERITY_UNSPECIFIED = 0;
+  SPEC_DIAGNOSTIC_SEVERITY_INFO = 1;
+  SPEC_DIAGNOSTIC_SEVERITY_WARNING = 2;
+  SPEC_DIAGNOSTIC_SEVERITY_ERROR = 3;
+}
+
+enum SpecCacheMode {
+  SPEC_CACHE_MODE_UNSPECIFIED = 0;
+  SPEC_CACHE_MODE_READ_WRITE = 1;
+  SPEC_CACHE_MODE_READ_ONLY = 2;
+  SPEC_CACHE_MODE_BYPASS = 3;
+}

--- a/src/Geospatial.Grpc/Geospatial.Grpc.csproj
+++ b/src/Geospatial.Grpc/Geospatial.Grpc.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <PackageId>Geospatial.Grpc</PackageId>
+    <Version>0.1.0-alpha.1</Version>
+    <Description>Generated .NET bindings for the Geospatial gRPC protocol standard.</Description>
+    <Authors>Geospatial gRPC Standard Contributors</Authors>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/honua-io/geospatial-grpc</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/honua-io/geospatial-grpc</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>geospatial;grpc;protobuf;gis;features;forms;geoprocessing</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.34.1" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.76.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.80.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\..\geospatial\v1\*.proto"
+              GrpcServices="Both"
+              ProtoRoot="..\.." />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\geospatial\v1\*.proto"
+          Pack="true"
+          PackagePath="proto/geospatial/v1/%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds the canonical .NET protocol package path for `Geospatial.Grpc` and a dedicated GitHub Packages publish workflow.

## Details

- Adds `src/Geospatial.Grpc` to generate and pack C# bindings from the canonical `geospatial/v1` proto files.
- Adds a dry-run-capable publish workflow for `geospatial-grpc-v*` tags and manual dispatches.
- Documents protocol ownership and downstream consumption rules so SDK/mobile/server repos consume the package instead of copying proto files.
- Keeps upstream process/pipeline/render/build/deployment protocol additions intact and adds `SpecService` documentation.

## Validation

- `buf format --diff --exit-code`
- `buf lint`
- `buf breaking --against '.git#branch=main'`
- `dotnet pack src/Geospatial.Grpc/Geospatial.Grpc.csproj --configuration Release -o /tmp/geospatial-grpc-nupkgs /p:TreatWarningsAsErrors=true`
