### PR TITLE
ci: update artifact action for node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           esac
 
       - name: Upload Generated Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: generated-${{ matrix.language }}-code
           path: generated/${{ matrix.language }}/
@@ -164,7 +164,7 @@ jobs:
           buf build -o descriptors/image.json
 
       - name: Upload Schema Descriptors
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: protocol-descriptors
           path: descriptors/
@@ -192,7 +192,7 @@ jobs:
             /p:TreatWarningsAsErrors=true
 
       - name: Upload .NET package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: geospatial-grpc-dotnet-package
           path: nupkgs/

--- a/.github/workflows/publish-dotnet-protocol.yml
+++ b/.github/workflows/publish-dotnet-protocol.yml
@@ -119,7 +119,7 @@ jobs:
           popd >/dev/null
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: geospatial-grpc-dotnet-${{ github.run_id }}-packages
           path: nupkgs/*.nupkg


### PR DESCRIPTION
## Summary
- bump geospatial CI and protocol package publish artifact uploads from actions/upload-artifact@v4 to @v7
- remove the Node 20 deprecation warning emitted by the protocol package publish workflow

## Validation
- python3 YAML parse for .github/workflows/ci.yml and .github/workflows/publish-dotnet-protocol.yml
- git diff --check