### PR TITLE
feat(v1): 3D scene, tile, and elevation gRPC services (honua-server#1194)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           esac
 
       - name: Upload Generated Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: generated-${{ matrix.language }}-code
           path: generated/${{ matrix.language }}/
@@ -164,7 +164,7 @@ jobs:
           buf build -o descriptors/image.json
 
       - name: Upload Schema Descriptors
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: protocol-descriptors
           path: descriptors/
@@ -192,7 +192,7 @@ jobs:
             /p:TreatWarningsAsErrors=true
 
       - name: Upload .NET package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: geospatial-grpc-dotnet-package
           path: nupkgs/

--- a/.github/workflows/publish-dotnet-protocol.yml
+++ b/.github/workflows/publish-dotnet-protocol.yml
@@ -119,7 +119,7 @@ jobs:
           popd >/dev/null
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: geospatial-grpc-dotnet-${{ github.run_id }}-packages
           path: nupkgs/*.nupkg

--- a/geospatial/v1/elevation_service.proto
+++ b/geospatial/v1/elevation_service.proto
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+import "geospatial/v1/common.proto";
+import "geospatial/v1/spatial_types.proto";
+
+// ElevationService provides typed RPC access to terrain elevation sampling.
+//
+// GetElevation samples a single point value; GetElevationProfile samples
+// ordered distance/elevation pairs along a polyline. The semantics mirror the
+// server HTTP elevation API: queries run against a registered raster dataset
+// and layer, honor a mosaic rule for overlapping coverage, and report no-data
+// and out-of-bounds conditions explicitly. Profiles are sampled geodesically
+// and report cumulative distance in meters.
+service ElevationService {
+  // GetElevation returns the elevation value at a single point.
+  rpc GetElevation(GetElevationRequest) returns (GetElevationResponse);
+
+  // GetElevationProfile returns ordered distance/elevation samples along a polyline.
+  rpc GetElevationProfile(GetElevationProfileRequest) returns (GetElevationProfileResponse);
+}
+
+// GetElevationRequest samples elevation at a single point.
+message GetElevationRequest {
+  // Dataset identifier.
+  string dataset_id = 1;
+  // Layer identifier within the dataset.
+  int32 layer_id = 2;
+  // Query point. The optional z is ignored; x/y are interpreted in the
+  // request spatial reference (WGS 84 when unset).
+  PointGeometry point = 3;
+  // Spatial reference of the query point; WGS 84 when unset.
+  SpatialReference spatial_reference = 4;
+  // Mosaic rule selecting source rasters for overlapping coverage. Empty uses
+  // the dataset default.
+  string mosaic_rule = 5;
+}
+
+// GetElevationResponse returns the sampled elevation value.
+message GetElevationResponse {
+  // Sampled elevation in the source vertical unit (meters unless declared
+  // otherwise). Unset when no_data or out_of_bounds is true.
+  optional double elevation = 1;
+  // True when the query landed on a no-data pixel.
+  bool no_data = 2;
+  // True when the query point lies outside dataset coverage.
+  bool out_of_bounds = 3;
+  // Echoed query coordinates.
+  double x = 4;
+  double y = 5;
+  // Mosaic rule applied to the query.
+  string mosaic_rule = 6;
+  // Source coverage metadata.
+  ElevationSource source = 7;
+}
+
+// GetElevationProfileRequest samples elevation along a polyline.
+message GetElevationProfileRequest {
+  // Dataset identifier.
+  string dataset_id = 1;
+  // Layer identifier within the dataset.
+  int32 layer_id = 2;
+  // Polyline to sample along. Reuses the canonical PolylineGeometry; the
+  // optional z on coordinates is ignored.
+  PolylineGeometry line = 3;
+  // Spatial reference of the line; WGS 84 when unset.
+  SpatialReference spatial_reference = 4;
+  // Number of evenly spaced samples to return; must be at least 2. Zero uses
+  // the server default.
+  int32 sample_count = 5;
+  // Mosaic rule selecting source rasters for overlapping coverage. Empty uses
+  // the dataset default.
+  string mosaic_rule = 6;
+}
+
+// GetElevationProfileResponse returns ordered profile samples.
+message GetElevationProfileResponse {
+  // Ordered samples from the start to the end of the line.
+  repeated ElevationProfileSample samples = 1;
+  // Total geodesic length of the sampled line in meters.
+  double line_length_meters = 2;
+  // Mosaic rule applied to the query.
+  string mosaic_rule = 3;
+  // True when every sample landed on no-data.
+  bool is_all_no_data = 4;
+  // Source coverage metadata.
+  ElevationSource source = 5;
+}
+
+// ElevationProfileSample is a single distance/elevation pair along a profile.
+message ElevationProfileSample {
+  // Cumulative geodesic distance from the line start in meters.
+  double distance_meters = 1;
+  // Sampled elevation. Unset when no_data is true.
+  optional double elevation = 2;
+  // True when this sample landed on a no-data pixel.
+  bool no_data = 3;
+}
+
+// ElevationSource describes the raster coverage backing an elevation result.
+message ElevationSource {
+  // Source raster identifiers contributing to the result.
+  repeated int64 raster_ids = 1;
+  // Source spatial reference, when known.
+  SpatialReference source_spatial_reference = 2;
+  // Pixel type label (for example "float32").
+  string pixel_type = 3;
+  // No-data sentinel value, when declared.
+  optional double no_data_value = 4;
+  // Vertical unit (for example "meters"), when declared.
+  string vertical_unit = 5;
+  // Vertical datum, when declared.
+  string vertical_datum = 6;
+}

--- a/geospatial/v1/scene_service.proto
+++ b/geospatial/v1/scene_service.proto
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+import "geospatial/v1/scene_types.proto";
+
+// SceneService provides typed RPC access to 3D scene catalogs and metadata.
+//
+// A scene is a publishable 3D view backed by a 3D Tiles tileset and an optional
+// terrain provider. This service exposes discovery (ListScenes) and metadata
+// retrieval (GetScene); tile payloads are delivered by TileService and terrain
+// sampling by ElevationService.
+service SceneService {
+  // ListScenes returns the catalog of available 3D scenes.
+  rpc ListScenes(ListScenesRequest) returns (ListScenesResponse);
+
+  // GetScene returns the metadata for a single 3D scene.
+  rpc GetScene(GetSceneRequest) returns (GetSceneResponse);
+}
+
+// SceneMetadata describes a single publishable 3D scene.
+message SceneMetadata {
+  // Stable scene identifier.
+  string scene_id = 1;
+  // Human-readable scene title.
+  string title = 2;
+  // Optional longer description.
+  string description = 3;
+  // URL of the root 3D Tiles tileset (tileset.json).
+  string tileset_url = 4;
+  // URL of the terrain provider backing the scene, when present.
+  string terrain_url = 5;
+  // Full 3D extent of the scene (horizontal envelope + min/max height).
+  Extent3D extent = 6;
+  // Suggested initial camera for first view.
+  Camera initial_camera = 7;
+  // Named viewpoints/bookmarks for the scene.
+  repeated Viewpoint viewpoints = 8;
+  // Scene-wide 3D styling, when published with the scene.
+  SceneStyle3D style = 9;
+  // Edition required to access the scene (for example "community", "pro",
+  // "enterprise"). Empty when unrestricted.
+  string edition = 10;
+  // Capability flags advertised for the scene (for example "terrain",
+  // "point-cloud", "i3dm", "styling").
+  repeated string capabilities = 11;
+}
+
+// ListScenesRequest specifies optional filtering and pagination for the catalog.
+message ListScenesRequest {
+  // Optional spatial constraint: only scenes intersecting this 3D extent.
+  Extent3D extent = 1;
+  // Pagination offset.
+  int32 result_offset = 2;
+  // Pagination limit; zero means server default.
+  int32 result_record_count = 3;
+}
+
+// ListScenesResponse contains the matching scene catalog entries.
+message ListScenesResponse {
+  repeated SceneMetadata scenes = 1;
+  // True when more entries are available beyond this page.
+  bool exceeded_transfer_limit = 2;
+}
+
+// GetSceneRequest identifies a single scene by id.
+message GetSceneRequest {
+  string scene_id = 1;
+}
+
+// GetSceneResponse returns the requested scene metadata.
+message GetSceneResponse {
+  SceneMetadata scene = 1;
+}

--- a/geospatial/v1/scene_types.proto
+++ b/geospatial/v1/scene_types.proto
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+import "geospatial/v1/common.proto";
+import "geospatial/v1/execution_types.proto";
+
+// Shared 3D scene types for the geospatial gRPC protocol standard.
+//
+// This file defines the camera, viewpoint, 3D extent, and styling/material
+// messages reused across SceneService, TileService, and ElevationService.
+// It is additive to the existing surface: 2D geometry and bounding boxes
+// continue to be expressed with PointGeometry/Coordinate (with optional z)
+// and Extent from spatial_types.proto / common.proto, which this file reuses
+// rather than redefining.
+
+// Extent3D represents a 3D bounding volume.
+//
+// The horizontal envelope reuses the canonical 2D Extent (xmin/ymin/xmax/ymax
+// plus spatial_reference). The vertical range is expressed as a min/max height
+// in meters above the scene's reference ellipsoid/geoid, matching the optional
+// z convention on PointGeometry and Coordinate.
+message Extent3D {
+  // Horizontal bounding box (reuses the canonical 2D envelope).
+  Extent extent = 1;
+  // Minimum height in meters.
+  double min_height = 2;
+  // Maximum height in meters.
+  double max_height = 3;
+}
+
+// Camera describes a 3D camera position and orientation.
+//
+// Position is geographic (lon/lat/height); orientation uses the standard
+// heading/pitch/roll triple in degrees. fov is optional so consumers can fall
+// back to a viewer default when it is not supplied.
+message Camera {
+  double longitude = 1; // Degrees
+  double latitude = 2; // Degrees
+  double height = 3; // Meters above the reference surface
+  double heading = 4; // Degrees, clockwise from north
+  double pitch = 5; // Degrees, negative looks down
+  double roll = 6; // Degrees
+  optional double fov = 7; // Vertical field of view in degrees
+}
+
+// Viewpoint is a named camera position suitable for bookmarks and initial views.
+message Viewpoint {
+  string id = 1; // Stable viewpoint identifier
+  string title = 2; // Human-readable label
+  Camera camera = 3; // Camera for this viewpoint
+}
+
+// MaterialOverride carries a glTF material override applied to 3D content.
+//
+// Scalar PBR factors are expressed with optional fields so an unset factor
+// leaves the source material value untouched. Free-form or vendor-specific
+// material extensions are carried in extensions using the canonical
+// ParameterMap convention shared with style overrides.
+message MaterialOverride {
+  // Base color as RGBA, each channel in [0, 1]. Empty leaves the source unchanged.
+  repeated double base_color_factor = 1;
+  optional double metallic_factor = 2; // [0, 1]
+  optional double roughness_factor = 3; // [0, 1]
+  // Emissive color as RGB, each channel in [0, 1].
+  repeated double emissive_factor = 4;
+  // Vendor-specific or extended material properties.
+  ParameterMap extensions = 5;
+}
+
+// FeatureStyle3D describes per-feature 3D appearance overrides.
+message FeatureStyle3D {
+  // Feature identifier the override applies to.
+  int64 feature_id = 1;
+  // Color as RGBA, each channel in [0, 1]. Empty leaves the source unchanged.
+  repeated double color = 2;
+  optional double opacity = 3; // [0, 1]
+  optional bool visible = 4; // Hide/show the feature
+  // Optional glTF material override for this feature.
+  MaterialOverride material = 5;
+}
+
+// SceneStyle3D describes scene-wide 3D styling.
+//
+// The expression field carries a 3D Tiles styling expression
+// (https://github.com/CesiumGS/3d-tiles/tree/main/specification/Styling) as an
+// opaque string; servers and viewers that understand the dialect evaluate it.
+// Per-feature overrides and free-form viewer hints use the same ParameterMap
+// convention as RenderSpec.style_spec and LayerBinding.style_overrides.
+message SceneStyle3D {
+  // 3D Tiles styling expression. Opaque to the protocol.
+  string expression = 1;
+  // Per-feature overrides.
+  repeated FeatureStyle3D feature_styles = 2;
+  // Free-form viewer styling hints (theme, lighting, palette).
+  ParameterMap style_hints = 3;
+}
+
+// TileContentType enumerates the supported 3D tile payload encodings.
+enum TileContentType {
+  TILE_CONTENT_TYPE_UNSPECIFIED = 0;
+  TILE_CONTENT_TYPE_B3DM = 1; // Batched 3D Model
+  TILE_CONTENT_TYPE_I3DM = 2; // Instanced 3D Model
+  TILE_CONTENT_TYPE_PNTS = 3; // Point cloud
+  TILE_CONTENT_TYPE_GLB = 4; // Binary glTF
+}
+
+// BoundingVolume describes the spatial bounds of a 3D tile node.
+//
+// A node carries exactly one representation, mirroring the 3D Tiles
+// boundingVolume oneof (region / box / sphere).
+message BoundingVolume {
+  oneof volume {
+    // Geographic region as a 3D extent (west/south/east/north + height range).
+    Extent3D region = 1;
+    // Oriented bounding box: 12 doubles (center xyz, then three half-axis vectors).
+    BoxVolume box = 2;
+    // Bounding sphere: center xyz plus radius.
+    SphereVolume sphere = 3;
+  }
+}
+
+// BoxVolume is an oriented bounding box expressed as 12 components.
+message BoxVolume {
+  // Center xyz followed by three half-axis vectors (12 values total).
+  repeated double components = 1;
+}
+
+// SphereVolume is a bounding sphere.
+message SphereVolume {
+  double center_x = 1;
+  double center_y = 2;
+  double center_z = 3;
+  double radius = 4;
+}
+
+// TileNode carries the metadata describing a single tile in the tileset tree.
+message TileNode {
+  // Stable node identifier within the scene's tileset.
+  string node_id = 1;
+  // Bounding volume of the node.
+  BoundingVolume bounding_volume = 2;
+  // Geometric error in meters used for LOD selection.
+  double geometric_error = 3;
+  // Level of detail this node belongs to.
+  int32 lod = 4;
+  // Child node identifiers, when present.
+  repeated string child_node_ids = 5;
+}

--- a/geospatial/v1/tile_service.proto
+++ b/geospatial/v1/tile_service.proto
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Geospatial gRPC Standard Contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+syntax = "proto3";
+
+package geospatial.v1;
+
+import "geospatial/v1/scene_types.proto";
+
+// TileService delivers 3D Tiles and point-cloud tile payloads for a scene.
+//
+// GetTile fetches a single tile by node identifier. StreamTiles delivers tiles
+// progressively for a scene by level of detail and spatial extent, following
+// the server-streaming idiom used by FeatureService.QueryFeaturesStream and
+// RenderService.ExecuteRenderStream: tiles are emitted as they become ready
+// and the stream completes when the requested set is exhausted.
+service TileService {
+  // GetTile returns a single tile payload for a scene node.
+  rpc GetTile(GetTileRequest) returns (GetTileResponse);
+
+  // StreamTiles streams tile payloads for a scene by LOD and spatial extent.
+  rpc StreamTiles(StreamTilesRequest) returns (stream Tile);
+}
+
+// Tile carries a single 3D tile payload and its node metadata.
+message Tile {
+  // Node metadata: bounding volume, geometric error, and LOD.
+  TileNode node = 1;
+  // Payload encoding.
+  TileContentType content_type = 2;
+  // Raw tile bytes in the encoding indicated by content_type.
+  bytes content = 3;
+}
+
+// GetTileRequest fetches a single tile by scene and node id.
+message GetTileRequest {
+  string scene_id = 1;
+  // Node identifier within the scene's tileset.
+  string node_id = 2;
+}
+
+// GetTileResponse returns the requested tile.
+message GetTileResponse {
+  Tile tile = 1;
+}
+
+// StreamTilesRequest requests progressive tile delivery for a scene.
+message StreamTilesRequest {
+  // Scene identifier.
+  string scene_id = 1;
+  // Spatial extent to cover; empty requests the full scene.
+  Extent3D extent = 2;
+  // Maximum level of detail to deliver; zero means all available LODs.
+  int32 max_lod = 3;
+  // Minimum level of detail to deliver.
+  int32 min_lod = 4;
+  // Maximum geometric error (meters) to honor for LOD selection; zero means
+  // server default.
+  double max_geometric_error = 5;
+}


### PR DESCRIPTION
Implements honua-io/honua-server#1194 (Epic honua-io/honua-server#530).

First-cut gRPC protocol for 3D geospatial scenes (Apache-2.0 open protocol):
- `scene_types.proto`: Camera, Viewpoint, Extent3D, SceneStyle3D, MaterialOverride, BoundingVolume, TileNode, TileContentType.
- `scene_service.proto` (ListScenes/GetScene → SceneMetadata), `tile_service.proto` (GetTile + server-streaming StreamTiles), `elevation_service.proto` (GetElevation + GetElevationProfile).

## Testing
buf lint clean.

## Note
PR also includes a pre-existing local `ci: update artifact action for node24` commit ahead of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)