### PR TITLE
Add release checklist and generated-client coordination contract (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ for feature in response.features:
 - **[Protocol Ownership](docs/proto-ownership.md)** - Canonical proto ownership and downstream sync rules
 - **[Getting Started Guide](docs/getting-started.md)** - Developer quick start
 - **[Versioning Policy](VERSIONING.md)** - Compatibility guarantees and change governance
+- **[Release Checklist](docs/release-checklist.md)** - Release coordination and generated-client regeneration workflow
 - **[Examples](examples/)** - Code samples for multiple languages
 
 ## 🏗️ Repository Structure

--- a/docs/proto-ownership.md
+++ b/docs/proto-ownership.md
@@ -31,6 +31,9 @@ update generated clients or compatibility adapters.
 Breaking changes require a new package/version path, such as `geospatial/v2`,
 unless every affected consumer has an explicit migration plan.
 
+For the full owner workflow — release, tag, publish, and per-SDK regeneration
+coordination — follow [docs/release-checklist.md](release-checklist.md).
+
 ## Compatibility Rules
 
 - Prefer additive fields, messages, methods, and enum values.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,124 @@
+# Release Checklist and Generated-Client Coordination
+
+This document is the canonical release-coordination contract for `geospatial-grpc`.
+Its purpose is to ensure that proto changes never strand downstream SDKs: every
+change that touches the wire surface has an explicit, repeatable path from a
+merged `.proto` edit to regenerated, published, and consumed client artifacts.
+
+It complements two existing documents and does not duplicate them:
+
+- [VERSIONING.md](../VERSIONING.md) — *what* counts as additive vs. breaking,
+  version numbering, deprecation, and breaking-change governance.
+- [docs/proto-ownership.md](proto-ownership.md) — *who* owns which contract and
+  the downstream-repo sync rules.
+
+This checklist is the *when and how* of releasing: the owner workflow and the
+gate a proto change passes through before downstream SDKs regenerate.
+
+## Audience and Roles
+
+| Role | Who | Responsibility |
+| --- | --- | --- |
+| **Proto owner** | Author of the proto PR in this repo | Drives the change through this checklist end to end, including coordinating downstream regeneration. Owns the change until every affected SDK consumes it. |
+| **Maintainer / reviewer** | A `geospatial-grpc` maintainer | Verifies CI is green, the change is correctly classified, and the downstream coordination plan exists before merge. |
+| **Downstream SDK owner** | Owner of `honua-server`, `honua-sdk-dotnet`, `honua-mobile`, etc. | Regenerates/pins clients from the released revision and confirms back on the tracking issue. |
+
+The proto owner stays accountable for the change until downstream regeneration
+is confirmed. "Merged" is not "done"; "consumed by every affected SDK" is.
+
+## Generated-Client Expectations (explicit, not tribal)
+
+These are the standing expectations for what a proto change must produce.
+
+1. **The protos are the only source of truth.** No downstream repo edits a local
+   `.proto`; they generate or pin from a tagged revision / Buf digest / published
+   package of this repo. See [proto-ownership.md](proto-ownership.md).
+2. **Every wire-surface change is released, not just merged.** A change to any
+   `geospatial/v1/*.proto` that affects the wire or JSON surface results in a
+   tagged semver release (see [VERSIONING.md](../VERSIONING.md#release-process)),
+   so downstream consumers have a stable coordinate to pin to.
+3. **Generation targets stay in lockstep.** The change must regenerate cleanly
+   for every configured language in `buf.gen.yaml` (C#, Go, TypeScript, Java,
+   Python, Rust, Swift, plus API docs). CI runs `buf generate`; a target that
+   no longer generates is a release blocker, not a follow-up.
+4. **The .NET package is the reference SDK.** `src/Geospatial.Grpc/` packs the
+   `Geospatial.Grpc` NuGet package and must build warning-clean under
+   `TreatWarningsAsErrors=true`. Its `<Version>` is bumped in the same PR as the
+   proto change (see the per-change steps below).
+5. **Examples and docs move with the surface.** When a change alters or adds
+   observable behavior, update the affected entries under `examples/` and the
+   relevant `docs/` (`specification.md`, `features/README.md`, generated
+   `docs/api`).
+6. **Coordination is recorded, not remembered.** A tracking issue captures the
+   released coordinate (commit, Buf digest, package version, or tag) and the
+   per-downstream regeneration status. Tribal knowledge is not a coordination
+   mechanism.
+
+## Pre-Merge Checklist (proto owner, in this repo)
+
+Run before requesting review / merging the proto PR.
+
+- [ ] **Classify the change** per the table in
+  [VERSIONING.md](../VERSIONING.md#change-classification): Additive,
+  Additive-with-care, Documentation, or Breaking. Breaking changes follow the
+  governance gate in VERSIONING.md and do **not** use this fast-path checklist —
+  they create a new package path (`geospatial/v2`) and a migration guide.
+- [ ] **Local validation passes** (pinned buf `1.66.0`):
+  - [ ] `buf format --diff --exit-code`
+  - [ ] `buf lint`
+  - [ ] `buf breaking --against '.git#branch=trunk'`
+  - [ ] `buf generate` (all `buf.gen.yaml` targets regenerate cleanly)
+- [ ] **.NET package** packs and builds warning-clean:
+  `dotnet pack src/Geospatial.Grpc/Geospatial.Grpc.csproj --configuration Release -o ./nupkgs /p:TreatWarningsAsErrors=true`
+- [ ] **Bump the package version** in `src/Geospatial.Grpc/Geospatial.Grpc.csproj`
+  (`<Version>`) following the minor/patch rules in
+  [VERSIONING.md](../VERSIONING.md#version-numbering). The release tag must match
+  this value exactly (`geospatial-grpc-v<Version>`), as enforced by the publish
+  workflow.
+- [ ] **Examples and docs updated** for any observable behavior change.
+- [ ] **Downstream impact noted in the PR description**: list the SDKs/repos that
+  must regenerate (cross-reference [proto-ownership.md](proto-ownership.md)'s
+  consumer table) and link or open the tracking issue.
+
+## Release Checklist (after merge to `trunk`)
+
+- [ ] **Confirm CI is green on `trunk`** (lint, breaking, format, multi-language
+  generation, descriptor export, .NET pack).
+- [ ] **Tag the release**: `geospatial-grpc-v<Version>`, where `<Version>`
+  matches the `.csproj` `<Version>` exactly. Pushing this tag triggers
+  `publish-dotnet-protocol.yml`.
+- [ ] **Verify the publish workflow** succeeds: package smoke (pack + install
+  smoke against a fresh `net10.0` project) and publish to GitHub Packages.
+  - A `workflow_dispatch` with `dry_run: true` validates packaging without
+    publishing if you want a pre-tag check.
+- [ ] **Publish Buf artifacts** if the registry is in use for this change
+  (`buf push`, CI-side, needs `BUF_TOKEN`); record the resulting module digest.
+- [ ] **Record the released coordinate** on the tracking issue: tag, `.csproj`
+  version, commit SHA, and Buf digest (whichever downstream consumers will pin).
+
+## Downstream Coordination Checklist (per affected SDK)
+
+The proto owner drives this; the downstream SDK owner executes and confirms.
+This mirrors the per-repo steps in
+[proto-ownership.md](proto-ownership.md#downstream-sync-checklist).
+
+- [ ] For each consumer in scope (`honua-server`, `honua-sdk-dotnet`,
+  `honua-mobile`, `honua-server-admin`, …): open or link a downstream issue/PR
+  that pins the new released coordinate.
+- [ ] Downstream regenerates or updates package references (.NET consumers use
+  the `Geospatial.Grpc` NuGet package; others use generated artifacts / Buf
+  digest).
+- [ ] Downstream runs its compile, analyzer, and protocol integration tests
+  against the new revision.
+- [ ] Downstream confirms back on the tracking issue; the proto owner marks that
+  consumer done.
+- [ ] **Close the loop**: the change is "done" only when every affected SDK has
+  confirmed consumption (or explicitly deferred with a tracked follow-up).
+
+## Quick Reference: which doc do I need?
+
+| Question | Document |
+| --- | --- |
+| Is my change additive or breaking? How do I version/deprecate it? | [VERSIONING.md](../VERSIONING.md) |
+| Who owns this contract? What must each downstream repo do? | [proto-ownership.md](proto-ownership.md) |
+| What are the steps to release and coordinate regeneration? | **This document** |


### PR DESCRIPTION
## What

Adds a canonical release-coordination contract so proto changes never strand downstream SDKs, addressing the gap where generated-client expectations were tribal knowledge.

New `docs/release-checklist.md`:
- **Roles** — proto owner, maintainer/reviewer, downstream SDK owner, with the rule that "merged" is not "done"; a change is done only when every affected SDK has confirmed consumption.
- **Generated-client expectations** — protos are the only source of truth; every wire-surface change is released (not just merged); all `buf.gen.yaml` targets stay in lockstep; the `.NET` package is the reference SDK; examples/docs move with the surface; coordination is recorded on a tracking issue.
- **Pre-merge checklist** (proto owner) — change classification, local `buf` validation, `.NET` pack, package version bump, downstream impact in the PR description.
- **Release checklist** (after merge) — confirm CI green, tag `geospatial-grpc-v<Version>`, verify the publish workflow, record the released coordinate.
- **Downstream coordination checklist** (per affected SDK) — open/link downstream issue, regenerate/pin, run downstream tests, confirm back, close the loop.
- **Quick reference** mapping each question to VERSIONING.md / proto-ownership.md / this doc.

Wires the doc into discovery:
- README docs list gains a Release Checklist entry.
- `docs/proto-ownership.md` Change Rules links out to the full owner workflow.

The doc deliberately complements rather than duplicates `VERSIONING.md` (what counts as additive/breaking, versioning, deprecation governance) and `docs/proto-ownership.md` (who owns which contract, downstream sync rules). It references their existing anchors (`#change-classification`, `#release-process`, `#version-numbering`, `#downstream-sync-checklist`) and the actual `publish-dotnet-protocol.yml` tag/version contract.

## Scope

Full issue. Documentation-only; no proto surface change.

## Testing

Docs-only change, no `.proto` edits — `buf` lint/breaking/format and the .NET pack are unaffected. Verified all internal doc links resolve to existing files and headings (VERSIONING.md and proto-ownership.md anchors confirmed present). No build artifacts committed.

Closes #4