### PR TITLE
docs: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Geospatial gRPC Protocol Standard
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/honua-io/geospatial-grpc/badge)](https://scorecard.dev/viewer/?uri=github.com/honua-io/geospatial-grpc)
+
 > Open source gRPC protocol definitions for geospatial data access, mobile data collection, and execution workflows
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
Adds the public OpenSSF Scorecard badge to the README (score now published via the org security workflow). Part of the Phase 1 security program (honua-compliance #6).