### PR TITLE
ci: least-privilege workflow token permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: nuget
+    directory: "/src/Geospatial.Grpc"
+    schedule:
+      interval: weekly
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: "/examples/python"
+    schedule:
+      interval: weekly
+    groups:
+      pip-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/examples/javascript"
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [trunk]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   BUF_VERSION: "1.66.0"
   DOTNET_VERSION: "10.0.x"

--- a/.github/workflows/publish-dotnet-protocol.yml
+++ b/.github/workflows/publish-dotnet-protocol.yml
@@ -12,6 +12,9 @@ on:
     tags:
       - "geospatial-grpc-v*"
 
+permissions:
+  contents: read
+
 env:
   DOTNET_VERSION: "10.0.x"
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true


### PR DESCRIPTION
## Summary

Harden CI workflows for OpenSSF Scorecard **Token-Permissions** and add Dependabot configuration.

### Token-Permissions
- `ci.yml`: add top-level `permissions: { contents: read }`. The `publish` job retains its own job-level `contents: write` + `packages: write` (Buf push, release-tag push, fixture GitHub Releases) — unchanged.
- `publish-dotnet-protocol.yml`: add top-level `permissions: { contents: read }`. Both jobs already declare job-level scopes (`package-smoke`: `contents: read`; `publish`: `contents: read` + `packages: write` for GitHub Packages push) — unchanged.
- `security.yml`: already has a top-level `permissions` block — not modified.

No existing permissions were removed or reduced.

### Dependabot
Adds `.github/dependabot.yml` (none existed) with weekly schedules and minor+patch grouping for:
- `github-actions` (`/`)
- `nuget` (`/src/Geospatial.Grpc`)
- `pip` (`/examples/python`)
- `npm` (`/examples/javascript`)

### Validation
All edited/created YAML parses cleanly (`yaml.safe_load`). Actions are not SHA-pinned in this repo and no pinning validator exists, so action versions were left untouched.

### Open high/critical Dependabot alerts (report only — not fixed here)
- **high** `pip/protobuf` — JSON recursion depth bypass
- **high** `pip/protobuf` — protobuf-python potential DoS

A Dependabot auto-PR already exists for this: **#25** (`build(deps): bump protobuf from 5.29.2 to 5.29.6 in /examples/python`).

Do not merge without review.