### PR TITLE
Document lat/lon axis-order and units conventions (Closes #38)

### DIFF
--- a/geospatial/v1/common.proto
+++ b/geospatial/v1/common.proto
@@ -121,10 +121,16 @@ message StatisticDefinition {
 }
 
 // Extent represents a bounding box.
+//
+// Axis order matches PointGeometry/Coordinate: x is longitude/easting, y is
+// latitude/northing. Units follow spatial_reference (degrees for geographic CRS
+// such as EPSG:4326). When this Extent is reused as a 3D Tiles region (see
+// scene_types BoundingVolume.region) the angular bounds are RADIANS instead;
+// that contract is documented at the region field, not here.
 message Extent {
-  double xmin = 1;
-  double ymin = 2;
-  double xmax = 3;
-  double ymax = 4;
+  double xmin = 1; // Minimum x (longitude/easting), units per spatial_reference
+  double ymin = 2; // Minimum y (latitude/northing), units per spatial_reference
+  double xmax = 3; // Maximum x (longitude/easting), units per spatial_reference
+  double ymax = 4; // Maximum y (latitude/northing), units per spatial_reference
   SpatialReference spatial_reference = 5;
 }

--- a/geospatial/v1/form_service.proto
+++ b/geospatial/v1/form_service.proto
@@ -500,22 +500,37 @@ message FormAttachment {
   AttachmentMetadata metadata = 8;
 }
 
+// AttachmentMetadata carries capture-time context for a FormAttachment.
+//
+// Location is reported in lat/lon field order (latitude first), matching the GPS
+// fix delivered by mobile devices. Note this is the OPPOSITE axis order of
+// spatial_types PointGeometry/Coordinate (x=longitude, y=latitude): when copying
+// this location into a PointGeometry the axes must be swapped (x=longitude,
+// y=latitude), not assigned positionally.
 message AttachmentMetadata {
-  double latitude = 1; // GPS location when captured
-  double longitude = 2;
-  double altitude = 3;
-  double accuracy = 4;
+  double latitude = 1; // GPS latitude when captured, degrees (geographic CRS, e.g. EPSG:4326)
+  double longitude = 2; // GPS longitude when captured, degrees (geographic CRS, e.g. EPSG:4326)
+  double altitude = 3; // Meters above the reference surface
+  double accuracy = 4; // Horizontal accuracy radius, meters
   int64 timestamp = 5; // Capture timestamp
   string device_id = 6;
   map<string, string> exif_data = 7; // For photos
 }
 
+// SubmissionMetadata carries device and location context for a form submission.
+//
+// Location is reported in lat/lon field order (latitude first), matching the GPS
+// fix delivered by mobile devices. Note this is the OPPOSITE axis order of
+// spatial_types PointGeometry/Coordinate (x=longitude, y=latitude): when copying
+// this submission location into a PointGeometry the axes must be swapped
+// (x=longitude, y=latitude), not assigned positionally. This is the SubmitFormData
+// copy path most at risk of a silent coordinate swap.
 message SubmissionMetadata {
   string device_id = 1;
   string app_version = 2;
   string platform = 3;
-  double latitude = 4; // Submission location
-  double longitude = 5;
+  double latitude = 4; // Submission latitude, degrees (geographic CRS, e.g. EPSG:4326)
+  double longitude = 5; // Submission longitude, degrees (geographic CRS, e.g. EPSG:4326)
   int64 submission_time = 6;
   map<string, string> custom_metadata = 7;
 }

--- a/geospatial/v1/scene_types.proto
+++ b/geospatial/v1/scene_types.proto
@@ -37,9 +37,14 @@ message Extent3D {
 // Position is geographic (lon/lat/height); orientation uses the standard
 // heading/pitch/roll triple in degrees. fov is optional so consumers can fall
 // back to a viewer default when it is not supplied.
+//
+// Field order here is longitude-first (lon, lat), which matches PointGeometry's
+// (x=lon, y=lat) axis order but is the OPPOSITE of FormService location metadata
+// (AttachmentMetadata/SubmissionMetadata), which is latitude-first. Map fields by
+// name, not position, when moving coordinates between these messages.
 message Camera {
-  double longitude = 1; // Degrees
-  double latitude = 2; // Degrees
+  double longitude = 1; // Longitude, degrees (geographic CRS, e.g. EPSG:4326)
+  double latitude = 2; // Latitude, degrees (geographic CRS, e.g. EPSG:4326)
   double height = 3; // Meters above the reference surface
   double heading = 4; // Degrees, clockwise from north
   double pitch = 5; // Degrees, negative looks down
@@ -115,6 +120,13 @@ enum TileContentType {
 message BoundingVolume {
   oneof volume {
     // Geographic region as a 3D extent (west/south/east/north + height range).
+    //
+    // Per the 3D Tiles boundingVolume.region convention, the bounds are geodetic
+    // and angular: the horizontal Extent maps xmin=west, ymin=south, xmax=east,
+    // ymax=north. Angular bounds are in RADIANS (not degrees) and heights are in
+    // meters above the WGS 84 ellipsoid, with spatial_reference set to WGS 84
+    // (EPSG:4326). This differs from the degrees-based convention used elsewhere
+    // (PointGeometry, Camera); consumers must not assume degrees for region.
     Extent3D region = 1;
     // Oriented bounding box: 12 doubles (center xyz, then three half-axis vectors).
     BoxVolume box = 2;

--- a/geospatial/v1/spatial_types.proto
+++ b/geospatial/v1/spatial_types.proto
@@ -22,9 +22,15 @@ message Geometry {
 }
 
 // PointGeometry represents a single point.
+//
+// Axis order is (x, y): x is the longitude/easting, y is the latitude/northing.
+// For geographic coordinate systems (e.g. EPSG:4326) x is longitude in degrees
+// and y is latitude in degrees. This is x/y (lon/lat) order, the opposite of the
+// lat/lon field order used by FormService location metadata; copying a captured
+// (latitude, longitude) point into a PointGeometry requires x=longitude, y=latitude.
 message PointGeometry {
-  double x = 1;
-  double y = 2;
+  double x = 1; // Longitude / easting (degrees for geographic CRS, e.g. EPSG:4326)
+  double y = 2; // Latitude / northing (degrees for geographic CRS, e.g. EPSG:4326)
   optional double z = 3; // Elevation/height
   optional double m = 4; // Measure value
 }
@@ -35,9 +41,13 @@ message MultiPointGeometry {
 }
 
 // Coordinate is a single coordinate in a path or ring.
+//
+// Axis order is (x, y): x is longitude/easting, y is latitude/northing, matching
+// PointGeometry. For geographic CRS (e.g. EPSG:4326) x is longitude in degrees
+// and y is latitude in degrees.
 message Coordinate {
-  double x = 1;
-  double y = 2;
+  double x = 1; // Longitude / easting (degrees for geographic CRS, e.g. EPSG:4326)
+  double y = 2; // Latitude / northing (degrees for geographic CRS, e.g. EPSG:4326)
   optional double z = 3; // Elevation/height
   optional double m = 4; // Measure value
 }


### PR DESCRIPTION
Closes #38.

## Problem

Lat/lon axis ordering is inconsistent across messages, a silent coordinate-swap hazard:

- `form_service.proto` `AttachmentMetadata`/`SubmissionMetadata` are **latitude-first** (`latitude=1/4`, `longitude=2/5`).
- `scene_types.proto` `Camera` is **longitude-first** (`longitude=1`, `latitude=2`).
- `spatial_types.proto` `PointGeometry{x,y}` implies x=lon/y=lat but never said so.

A client copying a captured point from `SubmissionMetadata(lat,lon)` into a `PointGeometry(x=lon,y=lat)` swaps axes unless it flips — exactly the `SubmitFormData` path. Plus `BoundingVolume.region` reuses the generic `Extent` with no unit contract (3D Tiles regions are radians, not degrees).

## Fix (Option A: additive documentation)

Changing field order/semantics would be wire/source-breaking, so this is **documentation only** — no field numbers, names, types, or order changed:

- **`spatial_types.proto`** `PointGeometry` / `Coordinate`: document x=longitude/easting, y=latitude/northing (degrees for geographic CRS).
- **`form_service.proto`** `AttachmentMetadata` / `SubmissionMetadata`: document the latitude-first order, units (degrees), and the explicit swap needed when copying into a `PointGeometry`; call out `SubmitFormData` as the at-risk path.
- **`scene_types.proto`** `Camera`: note its longitude-first order vs FormService's latitude-first order; `BoundingVolume.region`: pin 3D Tiles west/south/east/north semantics with angular bounds in **radians** and heights in meters (WGS 84 / EPSG:4326).
- **`common.proto`** `Extent`: document x/y axis order and `spatial_reference`-driven units, with a pointer to the radians exception at `region`.

## Validation

- `buf format --diff --exit-code` — pass
- `buf lint` — pass
- `buf breaking --against trunk` — pass (comments are non-breaking)
- `conformance/run.sh` — 12 passed, 0 failed

## Regenerated artifacts

None included, and none needed: the repo does not commit generated code (no `gen/`, `generated/`, `descriptors/`, `*.pb.*` tracked) and the conformance goldens are comment-free JSON payloads, unaffected by doc-comment edits. CI regenerates per-language clients from the protos as usual.