### PR TITLE
fix(buf): close RPC-deletion breaking gap and repair aggregate codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,40 @@ jobs:
           path: generated/${{ matrix.language }}/
           retention-days: 30
 
+  generate-aggregate:
+    name: Generate Code (aggregate buf.gen.yaml)
+    runs-on: ubuntu-latest
+    needs: lint-and-validate
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Install Buf CLI
+        run: |
+          curl -fsSL -o "${RUNNER_TEMP}/buf" "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64"
+          chmod +x "${RUNNER_TEMP}/buf"
+          echo "${RUNNER_TEMP}" >> "$GITHUB_PATH"
+
+      # Exercise the canonical aggregate template that README/getting-started
+      # and the JS example tell consumers to run. The per-language matrix above
+      # never touches buf.gen.yaml, so plugin/namespace drift (and the Rust,
+      # Swift, and API-docs targets) would otherwise land green. Running the
+      # full template here covers every configured plugin on every PR.
+      - name: Generate All Languages (buf generate)
+        run: buf generate --template buf.gen.yaml --output generated/all
+
+      - name: Upload Aggregate Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: generated-all-code
+          path: generated/all/
+          retention-days: 30
+
   publish:
     name: Publish to Buf Registry
     runs-on: ubuntu-latest
-    needs: [lint-and-validate, generate]
+    needs: [lint-and-validate, generate, generate-aggregate]
     if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
     environment: production
     permissions:

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -8,10 +8,13 @@ managed:
       value: io.grpc.geospatial
 plugins:
   # C# / .NET
+  # No base_namespace override: managed mode derives the namespace from the
+  # proto package (geospatial.v1 -> Geospatial.V1). A base_namespace must be a
+  # prefix of that namespace or the csharp plugin hard-fails; GeospatialGrpc is
+  # not a prefix of Geospatial.V1. This matches buf.gen.csharp.yaml and the
+  # published NuGet package.
   - remote: buf.build/protocolbuffers/csharp
     out: gen/csharp
-    opt:
-      - base_namespace=GeospatialGrpc
 
   # Go
   - remote: buf.build/protocolbuffers/go
@@ -49,10 +52,14 @@ plugins:
     out: gen/swift
 
   # Documentation
-  - remote: buf.build/protocolbuffers/doc
+  # buf.build/protocolbuffers/doc does not exist in the Buf registry; the
+  # canonical docs plugin is buf.build/community/pseudomuto-doc. Use its built-in
+  # markdown format (no external template file) so generation is self-contained:
+  # opt is "<format>,<output-filename>".
+  - remote: buf.build/community/pseudomuto-doc
     out: docs/api
     opt:
-      - docs/template.md,docs/api.md
+      - markdown,api.md
 
 inputs:
   - directory: .

--- a/buf.yaml
+++ b/buf.yaml
@@ -10,4 +10,13 @@ lint:
     - RPC_RESPONSE_STANDARD_NAME
 breaking:
   use:
+    # WIRE_JSON enforces field/enum wire+JSON compatibility (incl. reserved-aware
+    # field deletion via FIELD_NO_DELETE_UNLESS_NAME_RESERVED), but it does NOT
+    # include the RPC/service deletion rules. In gRPC the method path
+    # /geospatial.v1.Service/Method is part of the wire contract, so deleting or
+    # renaming an RPC or service breaks every existing client with UNIMPLEMENTED.
+    # Add the RPC/service no-delete rules to close that hole without losing the
+    # reserved-aware field-deletion behavior that PACKAGE/FILE would override.
     - WIRE_JSON
+    - RPC_NO_DELETE
+    - PACKAGE_SERVICE_NO_DELETE


### PR DESCRIPTION
## Summary

Repairs the Buf tooling that gates the proto contract and the documented
multi-language code-generation path. Three independent defects, all confirmed
against `origin/trunk`:

- **Breaking-change gate missed RPC/service deletion (S1, #44).** `buf.yaml`
  used only `WIRE_JSON`, which omits `RPC_NO_DELETE`, `SERVICE_NO_DELETE`, and
  `PACKAGE_SERVICE_NO_DELETE`. Deleting/renaming an RPC or service is a wire
  break (clients get `UNIMPLEMENTED`) but passed CI silently, contradicting the
  RPC-stability guarantee in `VERSIONING.md` and `docs/proto-ownership.md`.
  Added `RPC_NO_DELETE` + `PACKAGE_SERVICE_NO_DELETE` alongside `WIRE_JSON` so
  the reserved-aware field-deletion behaviour is preserved.

- **Default `buf generate` was broken for ALL languages (S1, #45; S2, #46).**
  The C# plugin set `base_namespace=GeospatialGrpc`, which is not a prefix of
  the managed namespace `Geospatial.V1` (hard fail), and the docs plugin
  referenced the non-existent remote `buf.build/protocolbuffers/doc` with a
  missing template file. buf aborts the whole invocation on any plugin error,
  so every documented `buf generate` command (README, getting-started) and the
  JS example failed. Dropped the C# `base_namespace` (matching
  `buf.gen.csharp.yaml` and the published NuGet) and switched docs to
  `buf.build/community/pseudomuto-doc` with its built-in markdown format.

- **CI never exercised the aggregate template (S2, #46).** The matrix ran only
  per-language templates, so aggregate/plugin drift plus the Rust, Swift, and
  API-docs targets landed green. Added a `generate-aggregate` job that runs
  `buf generate --template buf.gen.yaml` on every PR and gates `publish`.

## Verification

- `buf lint` passes.
- `buf config ls-breaking-rules --configured-only` now lists `RPC_NO_DELETE`
  and `PACKAGE_SERVICE_NO_DELETE`.
- Empirically: deleting `rpc ApplyEdits` and running
  `buf breaking --against '.git#ref=origin/trunk'` now FAILS with
  "Previously present RPC ApplyEdits ... was deleted" (was exit 0 before).
- `buf generate --template buf.gen.yaml` now completes exit 0, producing
  `gen/{csharp,go,typescript,java,python,rust,swift}` and `docs/api/api.md`.
- All edited YAML parses.

Fixes #44
Fixes #45
Fixes #46
