### PR TITLE
feat(v1): finalize pre-v1 wire contract — error model, severity, pagination

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -145,16 +145,23 @@ Jobs transition through these states: `DRAFT` → `VALIDATED` → `RUNNING` → 
 
 #### Error Model
 
-Execution errors are returned as `ErrorDetail` messages with:
+`ErrorDetail` is the single canonical application-error type for the protocol. It
+is reused (directly or embedded) by every surface that reports a structured
+error — execution/streaming terminal events, feature edit failures, and spec
+diagnostics — so clients parse one error shape everywhere. Fields 1-3 (`code`,
+`message`, `details`) are the canonical core; fields 4-8 carry optional
+execution context. It contains:
 
-- `error_code`: Machine-parseable error code
+- `code`: Numeric (`int32`) machine-parseable error code, aligned with
+  GeoServices/Esri REST error-code semantics where applicable
+- `message`: Human-readable error description
+- `details`: Optional key-value map for additional machine-readable context
 - `category`: Domain classification (validation, authorization, policy, execution, artifact, packaging, deployment)
 - `message`: Human-readable error description
 - `phase`: Execution phase where the error occurred (e.g., validation, planning, execution)
 - `node_id`: Identifies the plan step that produced the error (correlates to `PlanStep.step_id`; see [Node Identifier Convention](#node-identifier-convention))
 - `retryability`: How to recover (fix plan, fix data, retry transient error, permanent failure)
 - `suggested_action`: Human-readable recovery guidance
-- `details`: Optional key-value map for additional machine-readable context
 
 ### SpecService
 
@@ -640,24 +647,31 @@ Standard gRPC status codes are used for request-phase failures — errors detect
 
 ### Application Errors
 
-Application-specific errors are returned in response messages:
+Application-specific errors are returned in response messages using the canonical
+`ErrorDetail` (the former `EditError` and `SpecDiagnostic` string-code types were
+retired in favor of the one shared error model). For example, `EditResult.error`
+and `ApplyEditsResponse.error` carry an `ErrorDetail`:
 
 ```protobuf
-message EditError {
-  int32 code = 1;           // Application error code
-  string message = 2;       // Human-readable error message
+message ErrorDetail {
+  int32 code = 1;                    // Numeric application error code
+  string message = 2;               // Human-readable error message
+  map<string, string> details = 3;  // Additional machine-readable context
+  // ... optional execution-context fields 4-8
 }
 ```
 
 ### Validation Errors
 
-Form validation errors include severity levels:
+Form validation, spec diagnostics, and quality issues share one ascending
+`Severity` enum (`common.proto`); numeric casts preserve INFO < WARNING < ERROR:
 
 ```protobuf
-enum ValidationSeverity {
-  VALIDATION_SEVERITY_ERROR = 1;   // Prevents submission
-  VALIDATION_SEVERITY_WARNING = 2; // Shows warning but allows submission
-  VALIDATION_SEVERITY_INFO = 3;    // Informational only
+enum Severity {
+  SEVERITY_UNSPECIFIED = 0;
+  SEVERITY_INFO = 1;     // Informational only
+  SEVERITY_WARNING = 2;  // Shows warning but allows submission
+  SEVERITY_ERROR = 3;    // Prevents submission
 }
 ```
 

--- a/geospatial/v1/common.proto
+++ b/geospatial/v1/common.proto
@@ -120,6 +120,17 @@ message StatisticDefinition {
   string out_statistic_field_name = 3;
 }
 
+// Severity is the canonical severity classification shared across the protocol
+// (validation issues, diagnostics, quality findings). Values are ordered
+// ascending by seriousness so that a numeric comparison or cast preserves the
+// INFO < WARNING < ERROR relationship.
+enum Severity {
+  SEVERITY_UNSPECIFIED = 0;
+  SEVERITY_INFO = 1;
+  SEVERITY_WARNING = 2;
+  SEVERITY_ERROR = 3;
+}
+
 // Extent represents a bounding box.
 //
 // Axis order matches PointGeometry/Coordinate: x is longitude/easting, y is

--- a/geospatial/v1/execution_types.proto
+++ b/geospatial/v1/execution_types.proto
@@ -84,14 +84,6 @@ enum ArtifactClass {
   ARTIFACT_CLASS_SERVICE_DEFINITION = 9;
 }
 
-// IssueSeverity classifies the severity of a validation or quality issue.
-enum IssueSeverity {
-  ISSUE_SEVERITY_UNSPECIFIED = 0;
-  ISSUE_SEVERITY_ERROR = 1;
-  ISSUE_SEVERITY_WARNING = 2;
-  ISSUE_SEVERITY_INFO = 3;
-}
-
 // ExecutionPlan describes a sequence of steps to execute.
 message ExecutionPlan {
   string plan_id = 1;
@@ -113,20 +105,36 @@ message PlanStep {
   repeated string dependencies = 4;
 }
 
-// ErrorDetail provides structured error information for execution failures.
+// ErrorDetail is the canonical, structured application-error type for the
+// protocol. It is reused (directly or embedded) by every surface that reports a
+// structured error — streaming terminal error events, feature edit failures
+// (FeatureService), and spec diagnostics (SpecService) — so that clients parse
+// one error shape everywhere.
+//
+// Fields 1-3 are the canonical core (code, message, details); fields 4-8 carry
+// optional execution-context that the operator/execution surfaces populate and
+// that other surfaces simply leave unset.
 message ErrorDetail {
-  string error_code = 1;
-  ErrorCategory category = 2;
-  string message = 3;
+  // Numeric, machine-parseable error code. Aligned with GeoServices/Esri REST
+  // error-code semantics where applicable (e.g. 400 invalid/missing parameters,
+  // 403 forbidden, 404 not found, 498/499 token/auth, 500 internal server
+  // error); these also line up with HTTP/gRPC status conventions. 0 means
+  // unset.
+  int32 code = 1;
+  // Human-readable error message.
+  string message = 2;
+  // Additional machine-readable key/value context for the error.
+  map<string, string> details = 3;
+  // Domain of the error (execution surfaces).
+  ErrorCategory category = 4;
   // Descriptive label for the execution phase where the error occurred.
-  string phase = 4;
+  string phase = 5;
   // Correlates to the originating node: PlanStep.step_id (ProcessService),
   // PipelineStage.stage_id (PipelineService), or a server-chosen stage
   // identifier (RenderService, BuilderService, DeploymentService).
-  string node_id = 5;
-  Retryability retryability = 6;
-  string suggested_action = 7;
-  map<string, string> details = 8;
+  string node_id = 6;
+  Retryability retryability = 7;
+  string suggested_action = 8;
 }
 
 // ArtifactRef identifies a produced artifact and carries the canonical typed
@@ -232,7 +240,7 @@ message PlanValidationIssue {
   string node_id = 1;
   string field = 2;
   string message = 3;
-  IssueSeverity severity = 4;
+  Severity severity = 4;
 }
 
 // Assumption records a decision or inference made during execution.

--- a/geospatial/v1/feature_service.proto
+++ b/geospatial/v1/feature_service.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package geospatial.v1;
 
 import "geospatial/v1/common.proto";
+import "geospatial/v1/execution_types.proto";
 import "geospatial/v1/spatial_types.proto";
 
 // FeatureService provides typed RPC access to geospatial feature queries and editing.
@@ -89,18 +90,15 @@ message ApplyEditsResponse {
   repeated EditResult add_results = 1;
   repeated EditResult update_results = 2;
   repeated EditResult delete_results = 3;
-  EditError error = 4; // Global error if any
+  // Global error if any. Uses the canonical ErrorDetail (execution_types.proto);
+  // the former EditError type was retired in favor of the one shared error model.
+  ErrorDetail error = 4;
 }
 
 // EditResult is the outcome of a single create/update/delete operation.
 message EditResult {
   int64 object_id = 1; // Feature ID affected
   bool success = 2; // Operation success status
-  EditError error = 3; // Error details if failed
-}
-
-// EditError provides details for a failed edit operation.
-message EditError {
-  int32 code = 1; // Error code
-  string message = 2; // Human-readable error message
+  // Error details if failed. Canonical ErrorDetail (execution_types.proto).
+  ErrorDetail error = 3;
 }

--- a/geospatial/v1/form_service.proto
+++ b/geospatial/v1/form_service.proto
@@ -286,7 +286,9 @@ message ValidationRule {
   string rule_id = 1;
   ValidationType validation_type = 2;
   string error_message = 3;
-  ValidationSeverity severity = 4;
+  // Shared ascending Severity (common.proto). SEVERITY_ERROR prevents
+  // submission; SEVERITY_WARNING warns but allows; SEVERITY_INFO is advisory.
+  Severity severity = 4;
 
   oneof rule_config {
     RangeValidation range = 10;
@@ -305,13 +307,6 @@ enum ValidationType {
   VALIDATION_TYPE_PATTERN = 4;
   VALIDATION_TYPE_CUSTOM = 5;
   VALIDATION_TYPE_CONDITIONAL = 6;
-}
-
-enum ValidationSeverity {
-  VALIDATION_SEVERITY_UNSPECIFIED = 0;
-  VALIDATION_SEVERITY_ERROR = 1; // Prevents submission
-  VALIDATION_SEVERITY_WARNING = 2; // Shows warning but allows submission
-  VALIDATION_SEVERITY_INFO = 3; // Informational only
 }
 
 message RangeValidation {
@@ -544,7 +539,7 @@ message SubmissionResult {
 
 message ValidationIssue {
   string field_id = 1;
-  ValidationSeverity severity = 2;
+  Severity severity = 2;
   string message = 3;
   string suggested_value = 4; // Optional suggestion
 }
@@ -687,9 +682,16 @@ message GetFormMetadataRequest {
   repeated string form_ids = 1; // Empty = all forms
   repeated string tags = 2; // Filter by tags
   string service_id = 3; // Filter by target service
+  // Maximum number of catalog entries to return. Zero means server default.
+  int32 page_size = 4;
+  // Opaque continuation token from a prior response's next_page_token. Empty
+  // requests the first page.
+  string page_token = 5;
 }
 
 message GetFormMetadataResponse {
   repeated FormMetadata forms = 1;
   int32 total_count = 2;
+  // Continuation token for the next page; empty when no further pages remain.
+  string next_page_token = 3;
 }

--- a/geospatial/v1/pipeline_service.proto
+++ b/geospatial/v1/pipeline_service.proto
@@ -113,7 +113,7 @@ message QualityRule {
   string field = 3;
   string expression = 4;
   string message = 5;
-  IssueSeverity severity = 6;
+  Severity severity = 6;
 }
 
 // ValidatePipelineRequest asks the server to check a pipeline definition.
@@ -204,7 +204,7 @@ message QualityIssue {
   string field = 2;
   int64 affected_count = 3;
   string message = 4;
-  IssueSeverity severity = 5;
+  Severity severity = 5;
 }
 
 // PublishedServiceInfo describes the service created by a publishing pipeline.

--- a/geospatial/v1/scene_service.proto
+++ b/geospatial/v1/scene_service.proto
@@ -53,17 +53,18 @@ message SceneMetadata {
 message ListScenesRequest {
   // Optional spatial constraint: only scenes intersecting this 3D extent.
   Extent3D extent = 1;
-  // Pagination offset.
-  int32 result_offset = 2;
-  // Pagination limit; zero means server default.
-  int32 result_record_count = 3;
+  // Maximum number of catalog entries to return. Zero means server default.
+  int32 page_size = 2;
+  // Opaque continuation token from a prior response's next_page_token. Empty
+  // requests the first page. Replaces the retired int32 offset pagination.
+  string page_token = 3;
 }
 
 // ListScenesResponse contains the matching scene catalog entries.
 message ListScenesResponse {
   repeated SceneMetadata scenes = 1;
-  // True when more entries are available beyond this page.
-  bool exceeded_transfer_limit = 2;
+  // Continuation token for the next page; empty when no further pages remain.
+  string next_page_token = 2;
 }
 
 // GetSceneRequest identifies a single scene by id.

--- a/geospatial/v1/spec_service.proto
+++ b/geospatial/v1/spec_service.proto
@@ -5,6 +5,9 @@ syntax = "proto3";
 
 package geospatial.v1;
 
+import "geospatial/v1/common.proto";
+import "geospatial/v1/execution_types.proto";
+
 // SpecService exposes Terraform-style plan/apply semantics for canonical
 // geospatial spec documents. Plan is side-effect-free and returns the DAG shape
 // plus per-node cost estimates. Apply is server-streaming and emits per-node
@@ -121,11 +124,14 @@ message SpecApplySummary {
 }
 
 message SpecDiagnostic {
-  string code = 1;
-  string message = 2;
-  SpecDiagnosticSeverity severity = 3;
-  optional string node_id = 4;
-  optional string remedy = 5;
+  // Canonical error payload (numeric code, message, details, and the originating
+  // node_id). Replaces the former string code / message / node_id fields and
+  // converges spec diagnostics onto the one shared ErrorDetail model.
+  ErrorDetail error = 1;
+  // Diagnostic severity, using the shared ascending Severity enum.
+  Severity severity = 2;
+  // Optional remediation hint.
+  optional string remedy = 3;
 }
 
 // Enums.
@@ -151,13 +157,6 @@ enum SpecApplyEventKind {
   SPEC_APPLY_EVENT_KIND_APPLY_STARTED = 8;
   SPEC_APPLY_EVENT_KIND_APPLY_COMPLETED = 9;
   SPEC_APPLY_EVENT_KIND_APPLY_CANCELLED = 10;
-}
-
-enum SpecDiagnosticSeverity {
-  SPEC_DIAGNOSTIC_SEVERITY_UNSPECIFIED = 0;
-  SPEC_DIAGNOSTIC_SEVERITY_INFO = 1;
-  SPEC_DIAGNOSTIC_SEVERITY_WARNING = 2;
-  SPEC_DIAGNOSTIC_SEVERITY_ERROR = 3;
 }
 
 enum SpecCacheMode {

--- a/geospatial/v1/style_service.proto
+++ b/geospatial/v1/style_service.proto
@@ -24,17 +24,18 @@ service StyleService {
 
 // ListStylesRequest specifies optional pagination for the style catalog.
 message ListStylesRequest {
-  // Pagination offset.
-  int32 result_offset = 1;
-  // Pagination limit; zero means server default.
-  int32 result_record_count = 2;
+  // Maximum number of catalog entries to return. Zero means server default.
+  int32 page_size = 1;
+  // Opaque continuation token from a prior response's next_page_token. Empty
+  // requests the first page. Replaces the retired int32 offset pagination.
+  string page_token = 2;
 }
 
 // ListStylesResponse contains the matching style catalog entries.
 message ListStylesResponse {
   repeated StyleRef styles = 1;
-  // True when more entries are available beyond this page.
-  bool exceeded_transfer_limit = 2;
+  // Continuation token for the next page; empty when no further pages remain.
+  string next_page_token = 2;
 }
 
 // GetStyleRequest identifies a single style by id.


### PR DESCRIPTION
Closes #47.

Settles the three pre-v1 wire-contract inconsistencies from the S2 release audit (AUD-222/223/224/227/286) before the v1 cut. Each is cheap now and expensive/breaking after v1, so we take the breaks now while the contract is still pre-v1. The accepted recommendation on #47 is implemented in full.

## 1. Canonical error model
- `ErrorDetail` (`execution_types.proto`) is now the single application-error type. Its canonical core is exactly `int32 code = 1; string message = 2; map<string,string> details = 3;`, followed by the optional execution-context fields (`category`, `phase`, `node_id`, `retryability`, `suggested_action`) at 4–8.
- `error_code` is **`int32` everywhere** — the string variants are removed. Numeric `code` is documented to align with GeoServices/Esri REST error-code semantics (and HTTP/gRPC status conventions).
- `FeatureService.EditError` is retired; `EditResult.error` and `ApplyEditsResponse.error` now carry `ErrorDetail`.
- `SpecService.SpecDiagnostic` now embeds `ErrorDetail` (numeric code + details + node_id) instead of a string `code`.

## 2. Severity enum
- One ascending `Severity { SEVERITY_UNSPECIFIED = 0; SEVERITY_INFO = 1; SEVERITY_WARNING = 2; SEVERITY_ERROR = 3; }` in `common.proto`.
- Deletes the three duplicates — `IssueSeverity`, `ValidationSeverity`, `SpecDiagnosticSeverity` — and **fixes the inverted orderings** (both `IssueSeverity` and `ValidationSeverity` had `ERROR=1 … INFO=3`, so numeric casts inverted error/info). All references updated.

## 3. Pagination
- Standardized on token-based `page_size` (int32) + `page_token` (string) across the catalog list RPCs, with `next_page_token` on the responses.
- **Added pagination to `GetFormMetadata`** (was unbounded — could blow `MaxReceiveMessageSize` on large catalogs).
- **Removed the int32 `result_offset`/`result_record_count` overflow pattern from `StyleService` and `SceneService`**, converging them on the token model (replaced the `exceeded_transfer_limit` bool with `next_page_token`). FeatureService's Esri-style `QueryFeatures` result offset/count is intentionally left as-is (query semantics, not catalog listing).

## Intentional breaking change ⚠️
These are **deliberate pre-v1 wire/JSON-breaking changes** — `buf breaking` flags them and that is expected and correct for a v1 contract finalization. The break is confined to exactly the three areas above (verified: `buf breaking` reports only `ErrorDetail`, `*Severity`, `EditError`, `SpecDiagnostic`, and the scene/style/form pagination fields). There is no committed breaking-baseline image in the repo, so nothing to re-baseline; the CI PR breaking check is expected to report these.

**Downstream regen required:** `honua-sdk-dotnet`, `honua-sdk-js`, `honua-sdk-python` must regenerate from this contract (source breaks: int32 `code`, the unified `Severity`, removed `EditError`, new pagination fields). This is also in the same contract-freeze window as **honua-server#2252** (gRPC `FeatureQueryResult` missing spatialReference/geometryType/fields) — coordinate the regen together.

## Verification
- `buf lint` — clean.
- `buf format --diff --exit-code` — clean.
- `buf build` — succeeds.
- `buf generate --template buf.gen.yaml` — succeeds for all configured languages (C#, Go, TS, Java, Python, Rust, Swift, docs).
- `dotnet build src/Geospatial.Grpc` (Release, `TreatWarningsAsErrors`) — 0 warnings / 0 errors.
- `buf breaking` — reports the intended breaks only (expected).
