### PR TITLE
fix(examples,codegen): make the TypeScript example compile and emit _pb modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,42 @@ jobs:
           path: generated/all/
           retention-days: 30
 
+  examples-javascript:
+    name: Build JavaScript Example
+    runs-on: ubuntu-latest
+    needs: lint-and-validate
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Install Buf CLI
+        run: |
+          curl -fsSL -o "${RUNNER_TEMP}/buf" "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64"
+          chmod +x "${RUNNER_TEMP}/buf"
+          echo "${RUNNER_TEMP}" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # Generate the protobuf-es client and type-check/build the example so the
+      # advertised TypeScript onboarding example cannot regress. Without this the
+      # per-language matrix only proves codegen runs, not that the example that
+      # imports it actually compiles.
+      - name: Install Example Dependencies
+        working-directory: examples/javascript
+        run: npm ci
+
+      - name: Generate Client
+        working-directory: examples/javascript
+        run: npm run generate
+
+      - name: Build Example (tsc)
+        working-directory: examples/javascript
+        run: npm run build
+
   publish:
     name: Publish to Buf Registry
     runs-on: ubuntu-latest
@@ -349,11 +385,12 @@ jobs:
   notify:
     name: Notify Success
     runs-on: ubuntu-latest
-    needs: [lint-and-validate, generate, validate-schemas, conformance, dotnet-package, publish]
+    needs: [lint-and-validate, generate, examples-javascript, validate-schemas, conformance, dotnet-package, publish]
     if: |
       always() &&
       needs.lint-and-validate.result == 'success' &&
       needs.generate.result == 'success' &&
+      needs.examples-javascript.result == 'success' &&
       needs.validate-schemas.result == 'success' &&
       needs.conformance.result == 'success' &&
       needs.dotnet-package.result == 'success' &&

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ geospatial-grpc/
 
 ```bash
 # Clone the repository
-git clone https://github.com/mikemcdougall/geospatial-grpc.git
+git clone https://github.com/honua-io/geospatial-grpc.git
 cd geospatial-grpc
 
 # Validate protocols

--- a/buf.gen.javascript.yaml
+++ b/buf.gen.javascript.yaml
@@ -1,6 +1,9 @@
 version: v2
 plugins:
-  - remote: buf.build/connectrpc/es
+  # protoc-gen-es emits *_pb.js modules (messages, enums, and service
+  # descriptors). connectrpc/es only produced *_connect shims, which the docs
+  # and examples do not import, so generation produced nothing importable.
+  - remote: buf.build/bufbuild/es
     out: .
     opt:
       - target=js

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -25,7 +25,12 @@ plugins:
       - paths=source_relative
 
   # TypeScript / JavaScript (ES modules)
-  - remote: buf.build/connectrpc/es
+  # protoc-gen-es (buf.build/bufbuild/es) emits one *_pb module per .proto
+  # containing messages, enums, AND service descriptors. With @connectrpc/connect
+  # v2 those _pb service descriptors are passed directly to createClient, so the
+  # separate connectrpc/es *_connect shims are no longer required. The docs and
+  # examples import from *_pb modules, which only this plugin produces.
+  - remote: buf.build/bufbuild/es
     out: gen/typescript
     opt:
       - target=ts

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ buf --version
 ## Step 2: Clone the Repository
 
 ```bash
-git clone https://github.com/mikemcdougall/geospatial-grpc.git
+git clone https://github.com/honua-io/geospatial-grpc.git
 cd geospatial-grpc
 ```
 
@@ -95,7 +95,7 @@ cp -r ../gen/csharp/* .
 1. **Create a new Node.js project**:
 ```bash
 npm init -y
-npm install @connectrpc/connect @connectrpc/connect-node
+npm install @bufbuild/protobuf @connectrpc/connect @connectrpc/connect-node
 ```
 
 2. **Copy generated files**:

--- a/examples/javascript/.gitignore
+++ b/examples/javascript/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+# Generated protobuf-es client (produced by `npm run generate`).
+src/gen/

--- a/examples/javascript/buf.gen.yaml
+++ b/examples/javascript/buf.gen.yaml
@@ -1,0 +1,17 @@
+# Code-generation template for the JavaScript/TypeScript example.
+#
+# protoc-gen-es (buf.build/bufbuild/es) emits one *_pb.ts module per .proto,
+# each containing the messages, enums, and service descriptors defined in that
+# file. With @connectrpc/connect v2 the generated service descriptor is passed
+# straight to createClient, so no separate *_connect module is needed.
+#
+# `out: .` combined with `--output src/gen` (see package.json) writes files to
+# src/gen/<proto path>, e.g. src/gen/geospatial/v1/feature_service_pb.ts, which
+# matches the './gen/geospatial/v1/*_pb.js' import specifiers in src/index.ts.
+version: v2
+plugins:
+  - remote: buf.build/bufbuild/es
+    out: .
+    opt:
+      - target=ts
+      - import_extension=.js

--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -1,0 +1,600 @@
+{
+  "name": "geospatial-grpc-javascript-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "geospatial-grpc-javascript-example",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-node": "^2.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^26.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
-    "generate": "buf generate --template ../../buf.gen.yaml --include-imports --path ../../geospatial/v1 --output src/gen"
+    "generate": "buf generate --template buf.gen.yaml --output src/gen ../.."
   },
   "keywords": [
     "grpc",
@@ -19,6 +19,7 @@
   "author": "Geospatial gRPC Contributors",
   "license": "Apache-2.0",
   "dependencies": {
+    "@bufbuild/protobuf": "^2.2.0",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0"
   },

--- a/examples/javascript/src/index.ts
+++ b/examples/javascript/src/index.ts
@@ -1,26 +1,24 @@
+// protoc-gen-es emits one *_pb module per .proto and does not re-export symbols
+// across files, so each type must be imported from the module generated for the
+// .proto that defines it: services and their request types live with their
+// service, shared messages (SpatialReference, AttributeValue) live in common.
+import { create } from '@bufbuild/protobuf';
 import { FeatureService } from './gen/geospatial/v1/feature_service_pb.js';
-import { FormService } from './gen/geospatial/v1/form_service_pb.js';
 import {
-  QueryFeaturesRequest,
-  SpatialReference,
-  GetFormDefinitionRequest,
-  MobileCapabilities,
+  FormService,
+  SubmitFormDataRequestSchema,
   NetworkType,
   BatteryLevel,
-  SubmitFormDataRequest,
-  FormInstance,
   InstanceStatus,
-  SubmissionMetadata,
-  AttributeValue,
-} from './gen/geospatial/v1/feature_service_pb.js';
-import { createClient } from '@connectrpc/connect';
+} from './gen/geospatial/v1/form_service_pb.js';
+import { AttributeValueSchema } from './gen/geospatial/v1/common_pb.js';
+import type { FormDefinition } from './gen/geospatial/v1/form_service_pb.js';
+import { createClient, type Client } from '@connectrpc/connect';
 import { createGrpcTransport } from '@connectrpc/connect-node';
 
 // Configure transport
 const transport = createGrpcTransport({
   baseUrl: 'https://demo.geospatial-grpc.org',
-  httpVersion: '2',
-  acceptCompression: ['gzip'],
 });
 
 async function main() {
@@ -38,27 +36,29 @@ async function runFeatureServiceExample() {
   const client = createClient(FeatureService, transport);
 
   try {
-    // Query parks in San Francisco with area > 1000 sq ft
-    const request = new QueryFeaturesRequest({
+    // Query parks in San Francisco with area > 1000 sq ft. Connect's client
+    // methods accept a plain message-init object; nested messages (outSr) and
+    // int64 fields (bigint) are written inline.
+    const response = await client.queryFeatures({
       serviceId: 'sf-parks',
       layerId: 0,
       where: 'AREA > 1000',
       returnGeometry: true,
-      outSr: new SpatialReference({ wkid: 4326 }), // WGS84
+      outSr: { wkid: 4326 }, // WGS84
       resultRecordCount: 10,
     });
-
-    const response = await client.queryFeatures(request);
 
     console.log(`Found ${response.features.length} parks:`);
     for (const feature of response.features) {
       const nameAttr = feature.attributes['NAME'];
-      const name = nameAttr?.stringValue || 'Unknown';
+      const name =
+        nameAttr?.value.case === 'stringValue' ? nameAttr.value.value : 'Unknown';
 
       console.log(`  • ${name} (ID: ${feature.id})`);
 
-      if (feature.geometry?.point) {
-        const { x, y } = feature.geometry.point;
+      // Geometry is a oneof; the populated shape is reported via `shape.case`.
+      if (feature.geometry?.shape.case === 'point') {
+        const { x, y } = feature.geometry.shape.value;
         console.log(`    Location: ${x.toFixed(6)}, ${y.toFixed(6)}`);
       }
     }
@@ -77,22 +77,25 @@ async function runFormServiceExample() {
 
   try {
     // Get park inspection form definition
-    const formRequest = new GetFormDefinitionRequest({
+    const formResponse = await client.getFormDefinition({
       formId: 'park-inspection',
       serviceId: 'sf-parks',
       layerId: 0,
-      mobileCapabilities: new MobileCapabilities({
+      mobileCapabilities: {
         hasCamera: true,
         hasGps: true,
         platform: 'javascript',
         deviceType: 'desktop',
         networkType: NetworkType.WIFI,
         batteryLevel: BatteryLevel.HIGH,
-      }),
+      },
     });
 
-    const formResponse = await client.getFormDefinition(formRequest);
-    const form = formResponse.form!;
+    const form = formResponse.form;
+    if (!form) {
+      console.log('No form definition returned.');
+      return;
+    }
 
     console.log(`Form: ${form.title}`);
     console.log(`Description: ${form.description}`);
@@ -121,59 +124,72 @@ async function runFormServiceExample() {
   console.log();
 }
 
-async function demonstrateFormSubmission(client: ReturnType<typeof createClient<typeof FormService>>, form: any) {
+async function demonstrateFormSubmission(
+  client: Client<typeof FormService>,
+  form: FormDefinition,
+) {
   console.log('\n📤 Submitting sample form data...');
 
   const instanceId = crypto.randomUUID();
-  const now = Date.now();
+  const now = BigInt(Date.now()); // int64 timestamp fields are bigint
 
-  const submission = new SubmitFormDataRequest({
+  // Build the request as a typed message so field values can be populated from
+  // the form's controls below.
+  const submission = create(SubmitFormDataRequestSchema, {
     formId: form.formId,
     formVersion: form.version,
-    instance: new FormInstance({
+    instance: {
       instanceId,
       formId: form.formId,
       createdBy: 'demo-user',
       status: InstanceStatus.COMPLETE,
       createdAt: now,
       modifiedAt: now,
-      fieldValues: {},
-    }),
-    metadata: new SubmissionMetadata({
+    },
+    metadata: {
       deviceId: 'javascript-example',
       platform: 'javascript-example',
       appVersion: '1.0.0',
       latitude: 37.7749, // San Francisco
       longitude: -122.4194,
       submissionTime: now,
-    }),
+    },
   });
 
-  // Add sample field values based on form controls
+  // Add sample field values based on form controls. AttributeValue is a oneof,
+  // so the value is set via { case, value }.
   for (const control of form.controls) {
-    let value: AttributeValue;
-
     switch (control.controlType.case) {
-      case 'textInput':
-        value = new AttributeValue({ stringValue: 'Sample text value' });
-        break;
       case 'numericInput':
-        value = new AttributeValue({ int32Value: 42 });
+        submission.instance!.fieldValues[control.controlId] = create(AttributeValueSchema, {
+          value: { case: 'int32Value', value: 42 },
+        });
         break;
       case 'booleanControl':
-        value = new AttributeValue({ boolValue: true });
+        submission.instance!.fieldValues[control.controlId] = create(AttributeValueSchema, {
+          value: { case: 'boolValue', value: true },
+        });
         break;
       case 'datetimeControl':
-        value = new AttributeValue({ datetimeValue: now });
+        submission.instance!.fieldValues[control.controlId] = create(AttributeValueSchema, {
+          value: { case: 'datetimeValue', value: now },
+        });
         break;
       case 'locationControl':
-        value = new AttributeValue({ stringValue: 'POINT(-122.4194 37.7749)' });
+        submission.instance!.fieldValues[control.controlId] = create(AttributeValueSchema, {
+          value: { case: 'stringValue', value: 'POINT(-122.4194 37.7749)' },
+        });
+        break;
+      case 'textInput':
+        submission.instance!.fieldValues[control.controlId] = create(AttributeValueSchema, {
+          value: { case: 'stringValue', value: 'Sample text value' },
+        });
         break;
       default:
-        value = new AttributeValue({ stringValue: 'Default value' });
+        submission.instance!.fieldValues[control.controlId] = create(AttributeValueSchema, {
+          value: { case: 'stringValue', value: 'Default value' },
+        });
     }
-
-    submission.instance!.fieldValues[control.controlId] = value;
   }
 
   try {
@@ -182,7 +198,9 @@ async function demonstrateFormSubmission(client: ReturnType<typeof createClient<
     if (submitResponse.result?.success) {
       console.log('✅ Form submitted successfully!');
       console.log(`   Created feature ID: ${submitResponse.createdFeatureId}`);
-      console.log(`   Server timestamp: ${new Date(submitResponse.result.serverTimestamp)}`);
+      console.log(
+        `   Server timestamp: ${new Date(Number(submitResponse.result.serverTimestamp))}`,
+      );
     } else {
       console.log(`❌ Form submission failed: ${submitResponse.result?.message}`);
       for (const issue of submitResponse.validationIssues) {

--- a/examples/javascript/tsconfig.json
+++ b/examples/javascript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

The JavaScript/TypeScript onboarding example never compiled, and the configured TS/JS codegen never produced the `_pb` modules the docs and example import. This makes the advertised "type-safe, runnable" example actually build, and adds CI coverage so it cannot regress.

## Findings addressed

- **`examples/javascript/src/index.ts:3`** — imported `SpatialReference`, `AttributeValue` and 8 form types all from `feature_service_pb.js`. protoc-gen-es is one module per `.proto` with no cross-file re-exports, so 10/11 symbols were undefined and the example could not compile. Now each symbol is imported from its owning module: `FeatureService`/`QueryFeaturesRequest` from `feature_service_pb`, `FormService` + form types from `form_service_pb`, `SpatialReference`/`AttributeValue` from `common_pb`. The body was also migrated to the protobuf-es **v2** API that the v2 deps require (message-init objects / `create()`, oneof `{ case, value }` access, `bigint` for int64).
- **`buf.gen.yaml:28` and `buf.gen.javascript.yaml:3`** — the TS/JS target listed only `connectrpc/es`, which emits `*_connect` shims, not the `*_pb` modules the docs/examples import; `buf generate` produced nothing importable. Switched to `bufbuild/es` (protoc-gen-es), which emits `*_pb` modules (messages, enums, and the service descriptors consumed by `@connectrpc/connect` v2's `createClient`).
- **`README.md:239` and `docs/getting-started.md:35`** — clone URL pointed at the wrong org (`mikemcdougall`); corrected to `honua-io` to match every other canonical reference (csproj, fetch-fixtures.sh, badges).

## Supporting changes

- `examples/javascript/buf.gen.yaml` (new) + fixed `generate` script so output lands at `src/gen/geospatial/v1/*_pb.ts`, matching the import paths.
- Added `@bufbuild/protobuf` dependency, switched `tsconfig` `moduleResolution` to `bundler`, added a lockfile and `.gitignore` for build artifacts.
- `ci.yml`: new **Build JavaScript Example** job (`npm ci && npm run generate && npm run build`) wired into the `notify` gate, so the per-language matrix no longer green-lights an example that does not compile.
- `docs/getting-started.md`: added `@bufbuild/protobuf` to the TypeScript install instructions.

## Verification

Locally: `npm ci && npm run generate && npm run build` succeeds (tsc clean, `dist/` emitted) with buf 1.66.0 and the bufbuild/es remote plugin.