### PR TITLE
feat(v1): add idempotency keys to mutating RPCs; set BSR module name

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,4 +1,8 @@
 version: v1
+# BSR module name. `buf push` (CI's publish step, gated on BUF_TOKEN) requires a
+# module name under buf.yaml v1; without it the publish fails when credentials
+# are configured. Matches the canonical honua-io org used across the repo.
+name: buf.build/honua-io/geospatial-grpc
 lint:
   use:
     - STANDARD

--- a/geospatial/v1/builder_service.proto
+++ b/geospatial/v1/builder_service.proto
@@ -179,6 +179,11 @@ message BuildResult {
 message SubmitBuildJobRequest {
   BuildSpec spec = 1;
   ExecutionContext context = 2;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same submission
+  // and return the original job_id instead of spawning a duplicate job.
+  // Recommended: a UUID per logical submission.
+  string idempotency_key = 3;
 }
 
 // SubmitBuildJobResponse confirms build job submission.

--- a/geospatial/v1/deployment_service.proto
+++ b/geospatial/v1/deployment_service.proto
@@ -176,6 +176,11 @@ message SubmitDeploymentJobRequest {
   DeploymentSpec spec = 1;
   DeploymentOperationMode operation_mode = 2;
   ExecutionContext context = 3;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same submission
+  // and return the original job_id instead of spawning a duplicate job.
+  // Recommended: a UUID per logical submission.
+  string idempotency_key = 4;
 }
 
 // SubmitDeploymentJobResponse confirms deployment job submission.

--- a/geospatial/v1/feature_service.proto
+++ b/geospatial/v1/feature_service.proto
@@ -82,6 +82,12 @@ message ApplyEditsRequest {
   repeated int64 deletes = 5; // Feature IDs to delete
   bool rollback_on_failure = 6; // Transactional behavior
   bool force_write = 7; // Override optimistic locking
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same operation
+  // and return the original result instead of applying the edits a second time,
+  // so a retry after a lost response cannot create duplicate features.
+  // Recommended: a UUID per logical edit attempt.
+  string idempotency_key = 8;
 }
 
 // ApplyEditsResponse contains add/update/delete results.

--- a/geospatial/v1/pipeline_service.proto
+++ b/geospatial/v1/pipeline_service.proto
@@ -220,6 +220,11 @@ message PublishedServiceInfo {
 message SubmitPipelineJobRequest {
   PipelineDefinition pipeline = 1;
   ExecutionContext context = 2;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same submission
+  // and return the original job_id instead of spawning a duplicate job.
+  // Recommended: a UUID per logical submission.
+  string idempotency_key = 3;
 }
 
 // SubmitPipelineJobResponse confirms pipeline job submission.

--- a/geospatial/v1/process_service.proto
+++ b/geospatial/v1/process_service.proto
@@ -86,6 +86,11 @@ message DryRunPlanResponse {
 message ExecutePlanRequest {
   ExecutionPlan plan = 1;
   ExecutionContext context = 2;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same execution
+  // and return the original result instead of executing the plan again.
+  // Recommended: a UUID per logical execution attempt.
+  string idempotency_key = 3;
 }
 
 // ExecutePlanResponse returns the complete result of synchronous execution.
@@ -124,6 +129,11 @@ message ExecutionResult {
 message SubmitJobRequest {
   ExecutionPlan plan = 1;
   ExecutionContext context = 2;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same submission
+  // and return the original job_id instead of spawning a duplicate job.
+  // Recommended: a UUID per logical submission.
+  string idempotency_key = 3;
 }
 
 // SubmitJobResponse confirms job submission and returns the job identifier.

--- a/geospatial/v1/render_service.proto
+++ b/geospatial/v1/render_service.proto
@@ -188,6 +188,11 @@ message RenderResult {
 message SubmitRenderJobRequest {
   RenderSpec spec = 1;
   ExecutionContext context = 2;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same submission
+  // and return the original job_id instead of spawning a duplicate job.
+  // Recommended: a UUID per logical submission.
+  string idempotency_key = 3;
 }
 
 // SubmitRenderJobResponse confirms render job submission.


### PR DESCRIPTION
## Summary

Adds exactly-once safety to the write/submit path and fixes the BSR publish config. All proto changes are additive (new field numbers) — `buf lint`, `buf format`, and `buf breaking` (WIRE_JSON + RPC/service no-delete) all pass.

## Findings addressed

- **`feature_service.proto:77` (ApplyEditsRequest), `process_service.proto:86` (ExecutePlanRequest) / `:124` (SubmitJobRequest), and the Submit* siblings** — these mutating/submitting RPCs carried no client correlation token. gRPC clients retry on `DEADLINE_EXCEEDED`/`UNAVAILABLE`/transport reset, so a request that committed but lost its response would double-apply on retry: `ApplyEdits` creates duplicate features; the `Submit*` RPCs (server-assigned `job_id`) spawn a duplicate job. Added an optional, client-generated `idempotency_key` to each so a server can dedup retries within a documented window (mirrors how `SubmitFormData` already dedups via client-set `FormInstance.instance_id`):
  - `ApplyEditsRequest.idempotency_key = 8`
  - `ExecutePlanRequest.idempotency_key = 3`
  - `SubmitJobRequest.idempotency_key = 3`
  - `SubmitBuildJobRequest.idempotency_key = 3`
  - `SubmitDeploymentJobRequest.idempotency_key = 4`
  - `SubmitPipelineJobRequest.idempotency_key = 3`
  - `SubmitRenderJobRequest.idempotency_key = 3`
- **`buf.yaml:1`** — the v1 config had no `name`, which `buf push` requires; the CI publish step (gated on `BUF_TOKEN`) would fail when credentials are configured. Set `name: buf.build/honua-io/geospatial-grpc`, matching the canonical org used across the repo.

## Notes

This is the schema-side, additive half of the fix (the contract repo owns the `.proto` only). Honua-server must implement the actual dedup/idempotency enforcement against these keys — out of scope here.

## Verification

`buf lint`, `buf breaking --against '.git#branch=trunk'`, and `buf format -w` (no content changes) all clean against buf 1.66.0.