### PR TITLE
feat(v1): add idempotency_key to remaining mutating RPCs; fix retry docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -381,14 +381,20 @@ var channel = GrpcChannel.ForAddress("https://api.production.com", new GrpcChann
 
     // Retry configuration
     //
-    // IMPORTANT: only retry safe, read-only (idempotent) methods. The protocol
-    // does not define idempotency keys, so automatically retrying a mutation on
-    // a transient StatusCode.Unavailable can SILENTLY DUPLICATE the write — the
-    // original request may have already been applied on the server before the
-    // connection dropped. Do NOT use MethodName.Default here, because that would
-    // apply the retry policy to mutating RPCs such as
-    // FeatureService.ApplyEdits and FormService.SubmitFormData. Instead, scope
-    // the policy to specific read-only methods.
+    // IMPORTANT: read-only (idempotent) methods are always safe to retry.
+    // Mutating RPCs are only safe to retry when the request carries a stable
+    // idempotency_key: the server MUST treat a retry that reuses the same key
+    // within its dedup window as the same operation and return the original
+    // result, so a retry after a lost response cannot SILENTLY DUPLICATE the
+    // write. The protocol defines this idempotency_key field on the mutating
+    // RPCs — FeatureService.ApplyEdits, FormService.SubmitFormData, and the
+    // operator Submit*/Execute*/RollbackDeployment requests. Set a stable key
+    // (e.g. a UUID per logical attempt) before adding those methods to a retry
+    // policy. Do NOT use MethodName.Default to blanket-retry every method,
+    // because that would also retry mutations on calls where you did not set an
+    // idempotency_key, which can duplicate the write. Instead, scope the policy
+    // to specific read-only methods (below) plus any mutating method for which
+    // you always send an idempotency_key.
     ServiceConfig = new ServiceConfig
     {
         MethodConfigs =

--- a/geospatial/v1/builder_service.proto
+++ b/geospatial/v1/builder_service.proto
@@ -139,6 +139,12 @@ message DryRunBuildResponse {
 message ExecuteBuildRequest {
   BuildSpec spec = 1;
   ExecutionContext context = 2;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same execution
+  // and return the original result instead of executing the build again, so a
+  // retry after a lost response cannot produce duplicate packages.
+  // Recommended: a UUID per logical execution attempt.
+  string idempotency_key = 3;
 }
 
 // ExecuteBuildResponse returns the complete result of synchronous execution.

--- a/geospatial/v1/deployment_service.proto
+++ b/geospatial/v1/deployment_service.proto
@@ -131,6 +131,12 @@ message ExecuteDeploymentRequest {
   DeploymentSpec spec = 1;
   DeploymentOperationMode operation_mode = 2;
   ExecutionContext context = 3;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same execution
+  // and return the original result instead of creating the deployment again, so
+  // a retry after a lost response cannot create duplicate deployments.
+  // Recommended: a UUID per logical execution attempt.
+  string idempotency_key = 4;
 }
 
 // ExecuteDeploymentResponse returns the complete result of synchronous execution.
@@ -235,6 +241,11 @@ message RollbackDeploymentRequest {
   // immediately prior successful revision.
   string target_revision = 2;
   ExecutionContext context = 3;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same rollback
+  // and return the original result instead of performing the rollback again.
+  // Recommended: a UUID per logical rollback attempt.
+  string idempotency_key = 4;
 }
 
 // RollbackDeploymentResponse returns the outcome of a rollback operation.

--- a/geospatial/v1/form_service.proto
+++ b/geospatial/v1/form_service.proto
@@ -457,6 +457,13 @@ message SubmitFormDataRequest {
   FormInstance instance = 3;
   repeated FormAttachment attachments = 4;
   SubmissionMetadata metadata = 5;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same submission
+  // and return the original created_feature_id instead of creating the feature a
+  // second time, so an offline resubmit over a lossy link cannot create
+  // duplicate features. Recommended: a UUID per logical submission attempt
+  // (FormInstance.instance_id is a natural source for this value).
+  string idempotency_key = 6;
 }
 
 message SubmitFormDataResponse {

--- a/geospatial/v1/pipeline_service.proto
+++ b/geospatial/v1/pipeline_service.proto
@@ -143,6 +143,12 @@ message DryRunPipelineResponse {
 message ExecutePipelineRequest {
   PipelineDefinition pipeline = 1;
   ExecutionContext context = 2;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same execution
+  // and return the original result instead of executing the pipeline again, so a
+  // retry after a lost response cannot publish duplicate outputs.
+  // Recommended: a UUID per logical execution attempt.
+  string idempotency_key = 3;
 }
 
 // ExecutePipelineResponse returns the complete result of synchronous pipeline execution.

--- a/geospatial/v1/render_service.proto
+++ b/geospatial/v1/render_service.proto
@@ -143,6 +143,12 @@ message DryRunRenderResponse {
 message ExecuteRenderRequest {
   RenderSpec spec = 1;
   ExecutionContext context = 2;
+  // Optional client-generated idempotency key. When set, the server MUST treat
+  // a retry carrying the same key within its dedup window as the same execution
+  // and return the original result instead of executing the render again, so a
+  // retry after a lost response cannot produce duplicate artifacts.
+  // Recommended: a UUID per logical execution attempt.
+  string idempotency_key = 3;
 }
 
 // ExecuteRenderResponse returns the complete result of synchronous execution.


### PR DESCRIPTION
## Summary

Round-2 release-audit fix wave. All findings for this repo are one theme: the `idempotency_key` mechanism added in #57 (for `FeatureService.ApplyEdits` and the operator submit/plan RPCs) was not extended to the remaining mutating RPCs, and the onboarding doc still tells users no such mechanism exists. A lost response followed by an automatic retry on any of these calls duplicates the write (creates duplicate features, re-publishes, re-deploys). This PR closes the gap additively.

## Changes

### Protos — add optional `idempotency_key` to the remaining mutating RPCs
Same comment + MUST-dedup semantics as `ApplyEditsRequest`/`ExecutePlanRequest`; each uses the lowest free field number, so all additions are wire/JSON compatible (`buf breaking` clean).

- `geospatial/v1/form_service.proto:454` `SubmitFormDataRequest` — field 6. Creates a feature (`created_feature_id`) and is the mobile/offline capture surface (the canonical lost-response-retry scenario); a retried submission previously created duplicate features.
- `geospatial/v1/pipeline_service.proto:143` `ExecutePipelineRequest` — field 3.
- `geospatial/v1/render_service.proto:143` `ExecuteRenderRequest` — field 3.
- `geospatial/v1/builder_service.proto:139` `ExecuteBuildRequest` — field 3.
- `geospatial/v1/deployment_service.proto:130` `ExecuteDeploymentRequest` — field 4.
- `geospatial/v1/deployment_service.proto:232` `RollbackDeploymentRequest` — field 4.

### Docs — correct the production retry guidance
- `docs/getting-started.md:384` previously asserted "The protocol does not define idempotency keys" and told users to never retry `ApplyEdits`/`SubmitFormData`. That contradicted the shipped schema since #57. Updated to document that these mutating RPCs accept an `idempotency_key` and become safe to retry when a stable key (e.g. a UUID per logical attempt) is set, while keeping the warning against blanket `MethodName.Default` retries of mutations sent without a key.

## Audit findings addressed
By `file:line` + recommendation (these are new audit findings, not GH issues):
- `form_service.proto:454` — add idempotency_key to SubmitFormDataRequest (2 findings).
- `pipeline_service.proto:143` / `process_service.proto:93` — add idempotency_key to the four sibling synchronous Execute* RPCs + RollbackDeployment (2 findings).
- `docs/getting-started.md:384` — correct the idempotency/retry guidance (1 finding).

## Verification
- `buf format --diff --exit-code` — clean
- `buf lint` — clean
- `buf breaking --against origin/trunk` — clean (additive)
- `conformance/run.sh` — 12 passed, 0 failed
- `dotnet pack` (TreatWarningsAsErrors) — succeeded
