### PR TITLE
ci: idempotent release tagging + clean v* breaking baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,15 @@ jobs:
       - name: Check Breaking Changes (push vs previous release tag)
         if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
         run: |
-          # Compare the pushed trunk state against the most recent release tag.
+          # Compare the pushed trunk state against the most recent *curated*
+          # release tag. Curated release tags are the conformance "v<VERSION>"
+          # tags (e.g. v0.1.0-alpha.2); the per-push CI snapshot tags use the
+          # distinct "ci-snapshot/" namespace (see the publish job) so they do
+          # not pollute this baseline. Select the highest semver, not whatever
+          # tag happened to be pushed last.
           # If no release tag exists yet, there is no baseline to break against.
           git fetch --tags --quiet
-          prev_tag="$(git tag --list 'v*' --sort=-creatordate | head -n1)"
+          prev_tag="$(git tag --list 'v*' --sort=-version:refname | head -n1)"
           if [[ -z "${prev_tag}" ]]; then
             echo "No prior release tag found; skipping push-time breaking check (nothing to break against yet)."
             exit 0
@@ -214,14 +219,25 @@ jobs:
         if: steps.buf-auth.outputs.enabled == 'true'
         run: buf push
 
-      - name: Create Release Tag
+      - name: Create Snapshot Tag
         if: steps.buf-auth.outputs.enabled == 'true'
         run: |
-          # Generate a tag based on timestamp for versioning
-          TAG="v$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
-          echo "Creating tag: $TAG"
-          git tag $TAG
-          git push origin $TAG
+          # Per-push CI snapshot tag for traceability of registry pushes.
+          # Lives in the dedicated "ci-snapshot/" namespace (NOT "v*") so it
+          # never collides with curated release tags or the push-time breaking
+          # baseline. TAG is a pure function of date+SHA, so guard creation to
+          # keep workflow re-runs idempotent (mirrors the fixture-release guard
+          # below): on a re-run for the same commit/day the tag already exists
+          # and we skip instead of failing the publish job.
+          TAG="ci-snapshot/$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null \
+            || git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Snapshot tag ${TAG} already exists; skipping."
+          else
+            echo "Creating tag: ${TAG}"
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Findings addressed (round-4 audit, S2)

Both findings are in the release path of `.github/workflows/ci.yml`.

### 1. Non-idempotent auto-tag step breaks on workflow re-run (`.github/workflows/ci.yml:217`)
The publish job's "Create Release Tag" step ran `TAG="v$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)"; git tag $TAG; git push origin $TAG` with no existence guard. `TAG` is a pure function of date+SHA, so re-running the same workflow run on the same day/commit (a routine recovery action after a flaky downstream failure) fails with "tag already exists" and the whole publish job fails — after `buf push` already succeeded, leaving a half-completed publish that needs manual tag surgery to recover. The very next block (fixture release) was already made idempotent via a `gh release view` check; this step was the lone non-idempotent link.

### 2. Per-push date tags pollute the `v*` breaking baseline (`.github/workflows/ci.yml:52`)
The push-time breaking gate selected its baseline as `git tag --list 'v*' --sort=-creatordate | head -n1`, with a comment promising "the most recent release tag." But the publish job created a `v<date>-<sha>` tag on every trunk push (same `v*` glob), and those throwaway tags are always newest by creatordate, so the baseline was in practice the prior commit's throwaway tag — not a curated release. The documented semantics silently did not hold, and multi-commit cumulative drift vs. the last real release could escape push-time detection.

## Changes
- Moved the per-push snapshot tag to a dedicated `ci-snapshot/` namespace (no longer matches `v*`) and guarded creation so re-runs skip instead of failing (mirrors the fixture-release guard).
- Selected the push-time breaking baseline from curated `v*` tags only, sorted by `-version:refname` (highest semver) rather than `-creatordate`.

## Verification
- `python3 -c yaml.safe_load` parses ci.yml.
- No other docs/workflows reference the old tag scheme.

Recommendations from the audit's `recommendation` fields for these two file:line findings.