### PR TITLE
docs: fix broken TypeScript quick-start and examples workflow command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ dotnet pack src/Geospatial.Grpc/Geospatial.Grpc.csproj --configuration Release -
 Examples (each in its own directory):
 
 ```bash
-cd examples/typescript && npm install && npm start   # README references typescript; dir is examples/javascript
+cd examples/javascript && npm install && npm run generate && npm run dev
 cd examples/python && pip install -r requirements.txt && python main.py
 cd examples/dotnet && dotnet run
 ```
@@ -158,8 +158,6 @@ gen/                    # Generated client libraries (output, not committed sour
   enabled (`AnalysisMode=AllEnabledByDefault`); generated/compiled proto code
   must stay warning-clean. Bump `<Version>` in the `.csproj`; the publish
   workflow requires the `geospatial-grpc-v*` tag version to match it exactly.
-- **README example note:** the README references `examples/typescript`, but the
-  actual directory is `examples/javascript`.
 
 ## Shared dev-environment rules (multi-agent WSL)
 

--- a/README.md
+++ b/README.md
@@ -154,12 +154,16 @@ foreach (var feature in response.Features)
 
 #### TypeScript Example
 ```typescript
-import { FeatureService } from './gen/typescript/geospatial/v1/feature_service_pb';
+import { FeatureService } from './gen/geospatial/v1/feature_service_pb';
 import { createClient } from '@connectrpc/connect';
+import { createGrpcTransport } from '@connectrpc/connect-node';
 
-const client = createClient(FeatureService, {
+// connect v2 requires a Transport instance, not a baseUrl config object.
+const transport = createGrpcTransport({
   baseUrl: 'https://api.example.com'
 });
+
+const client = createClient(FeatureService, transport);
 
 const response = await client.queryFeatures({
   serviceId: 'parcels',
@@ -262,7 +266,7 @@ buf breaking --against '.git#branch=trunk'
 buf generate
 
 # Run examples
-cd examples/typescript && npm install && npm start
+cd examples/javascript && npm install && npm run generate && npm run dev
 ```
 
 ### Adding New Features


### PR DESCRIPTION
## Findings addressed (round-4 audit, S2)

### 1. README TS quick-start uses wrong connect v2 API and wrong import path (`README.md:160`)
The snippet called `createClient(FeatureService, { baseUrl })`, but `@connectrpc/connect` v2 requires a `Transport` instance as the second arg, so it fails to type-check and at runtime. It also imported from the nonexistent `./gen/typescript/geospatial/v1/feature_service_pb` path. Both `docs/getting-started.md` and `examples/javascript/src/index.ts` build a transport via `createGrpcTransport({ baseUrl })` and import from `./gen/geospatial/v1/...`.

### 2. Development Workflow `cd`s into a directory that does not exist (`README.md:265`)
`cd examples/typescript && npm install && npm start` — there is no `examples/typescript` (the example lives in `examples/javascript`), and even there `start` runs `dist/index.js` before `tsc` builds it; the working invocation is `npm run dev`. AGENTS.md documented this as a known mismatch.

## Changes
- Rewrote the README TS snippet to use `createGrpcTransport` + `createClient(FeatureService, transport)` and import from `./gen/geospatial/v1/feature_service_pb`.
- Changed the workflow command to `cd examples/javascript && npm install && npm run generate && npm run dev` (matches the example's `package.json` scripts).
- Fixed the same stale command in `AGENTS.md` and removed the now-resolved known-issue note.

Recommendations from the audit's `recommendation` fields for these two file:line findings.