### PR TITLE
build: pin all buf remote plugins to explicit versions

### DIFF
--- a/buf.gen.csharp.yaml
+++ b/buf.gen.csharp.yaml
@@ -1,6 +1,6 @@
 version: v2
 plugins:
-  - remote: buf.build/protocolbuffers/csharp
+  - remote: buf.build/protocolbuffers/csharp:v35.1
     out: .
-  - remote: buf.build/grpc/csharp
+  - remote: buf.build/grpc/csharp:v1.81.1
     out: .

--- a/buf.gen.go.yaml
+++ b/buf.gen.go.yaml
@@ -5,11 +5,11 @@ managed:
     - file_option: go_package_prefix
       value: github.com/geospatial-grpc/proto-go
 plugins:
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: .
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc/go
+  - remote: buf.build/grpc/go:v1.6.2
     out: .
     opt:
       - paths=source_relative

--- a/buf.gen.java.yaml
+++ b/buf.gen.java.yaml
@@ -1,6 +1,6 @@
 version: v2
 plugins:
-  - remote: buf.build/protocolbuffers/java
+  - remote: buf.build/protocolbuffers/java:v35.1
     out: .
-  - remote: buf.build/grpc/java
+  - remote: buf.build/grpc/java:v1.82.1
     out: .

--- a/buf.gen.javascript.yaml
+++ b/buf.gen.javascript.yaml
@@ -3,7 +3,7 @@ plugins:
   # protoc-gen-es emits *_pb.js modules (messages, enums, and service
   # descriptors). connectrpc/es only produced *_connect shims, which the docs
   # and examples do not import, so generation produced nothing importable.
-  - remote: buf.build/bufbuild/es
+  - remote: buf.build/bufbuild/es:v2.12.1
     out: .
     opt:
       - target=js

--- a/buf.gen.python.yaml
+++ b/buf.gen.python.yaml
@@ -1,6 +1,6 @@
 version: v2
 plugins:
-  - remote: buf.build/protocolbuffers/python
+  - remote: buf.build/protocolbuffers/python:v35.1
     out: .
-  - remote: buf.build/grpc/python
+  - remote: buf.build/grpc/python:v1.81.1
     out: .

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -13,13 +13,13 @@ plugins:
   # prefix of that namespace or the csharp plugin hard-fails; GeospatialGrpc is
   # not a prefix of Geospatial.V1. This matches buf.gen.csharp.yaml and the
   # published NuGet package.
-  - remote: buf.build/protocolbuffers/csharp
+  - remote: buf.build/protocolbuffers/csharp:v35.1
     out: gen/csharp
 
   # Go
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: gen/go
-  - remote: buf.build/grpc/go
+  - remote: buf.build/grpc/go:v1.6.2
     out: gen/go
     opt:
       - paths=source_relative
@@ -30,30 +30,30 @@ plugins:
   # v2 those _pb service descriptors are passed directly to createClient, so the
   # separate connectrpc/es *_connect shims are no longer required. The docs and
   # examples import from *_pb modules, which only this plugin produces.
-  - remote: buf.build/bufbuild/es
+  - remote: buf.build/bufbuild/es:v2.12.1
     out: gen/typescript
     opt:
       - target=ts
       - import_extension=.js
 
   # Java
-  - remote: buf.build/protocolbuffers/java
+  - remote: buf.build/protocolbuffers/java:v35.1
     out: gen/java
-  - remote: buf.build/grpc/java
+  - remote: buf.build/grpc/java:v1.82.1
     out: gen/java
 
   # Python
-  - remote: buf.build/protocolbuffers/python
+  - remote: buf.build/protocolbuffers/python:v35.1
     out: gen/python
-  - remote: buf.build/grpc/python
+  - remote: buf.build/grpc/python:v1.81.1
     out: gen/python
 
   # Rust
-  - remote: buf.build/community/neoeinstein-prost
+  - remote: buf.build/community/neoeinstein-prost:v0.5.0
     out: gen/rust
 
   # Swift
-  - remote: buf.build/grpc/swift
+  - remote: buf.build/grpc/swift:v1.27.5
     out: gen/swift
 
   # Documentation
@@ -61,7 +61,7 @@ plugins:
   # canonical docs plugin is buf.build/community/pseudomuto-doc. Use its built-in
   # markdown format (no external template file) so generation is self-contained:
   # opt is "<format>,<output-filename>".
-  - remote: buf.build/community/pseudomuto-doc
+  - remote: buf.build/community/pseudomuto-doc:v1.5.1
     out: docs/api
     opt:
       - markdown,api.md


### PR DESCRIPTION
## Finding addressed (round-4 audit, S2)

### buf codegen remote plugins are unpinned (`buf.gen.yaml:16` + per-language templates)
Every remote plugin reference across `buf.gen.yaml`, `buf.gen.csharp.yaml`, `buf.gen.go.yaml`, `buf.gen.java.yaml`, `buf.gen.python.yaml`, and `buf.gen.javascript.yaml` was unlabeled. An unlabeled `remote: buf.build/<owner>/<plugin>` resolves to whatever the BSR serves at generation time. The buf CLI pin (1.66.0) does **not** pin plugin versions — those are independent BSR artifacts — so the same `.proto` can emit different generated SDK code over time (reproducibility gap), and a regressed/compromised plugin release is consumed silently on the next CI codegen run or downstream `buf generate` (supply-chain surface). This contradicts the repo's stated deterministic-generation contract. The published .NET NuGet package is unaffected (it uses pinned `Grpc.Tools`).

## Changes
Pinned every remote plugin to an explicit version label, resolved from the BSR (latest curated version per plugin):

| plugin | pin |
|---|---|
| protocolbuffers/csharp | v35.1 |
| grpc/csharp | v1.81.1 |
| protocolbuffers/go | v1.36.11 |
| grpc/go | v1.6.2 |
| bufbuild/es | v2.12.1 |
| protocolbuffers/java | v35.1 |
| grpc/java | v1.82.1 |
| protocolbuffers/python | v35.1 |
| grpc/python | v1.81.1 |
| community/neoeinstein-prost | v0.5.0 |
| grpc/swift | v1.27.5 |
| community/pseudomuto-doc | v1.5.1 |

## Verification
- `buf generate` succeeds for all five per-language templates (the CI-exercised matrix) and for the root `buf.gen.yaml` (rust/swift/doc included).
- `buf lint` and `buf format --diff --exit-code` pass.

## Notes
- The audit referenced `examples/javascript/buf.gen.yaml`; that file no longer exists on trunk — the JS example now generates via the root `buf.gen.yaml` (`npm run generate`), so it inherits these pins.
- Follow-up (not in this PR): a CI guard asserting no unlabeled `remote:` plugin remains, and Dependabot/manual bump discipline — see the audit recommendation.

Recommendation from the audit's `recommendation` field for `buf.gen.yaml:16`.