### PR TITLE
docs(proto): document FormService's intentional error-model divergence

### DIFF
--- a/geospatial/v1/form_service.proto
+++ b/geospatial/v1/form_service.proto
@@ -9,6 +9,28 @@ import "geospatial/v1/common.proto";
 
 // FormService provides gRPC-native form definition and submission capabilities.
 // Designed as an alternative to OpenRosa XML with type-safe mobile optimization.
+//
+// Intentional divergence from the shared error model.
+//
+// Unlike the operator-execution and spec surfaces (ProcessService,
+// PipelineService, RenderService, BuilderService, DeploymentService,
+// SpecService) which embed the shared execution_types.proto ErrorDetail
+// (numeric code, ErrorCategory, Retryability, structured details),
+// FormService deliberately reports submission/validation outcomes through the
+// bespoke SubmissionResult / ValidationIssue pair below. These model
+// field-level, end-user-facing form validation feedback (per-`field_id`
+// messages with optional `suggested_value` corrections rendered inline on a
+// mobile device), not machine-driven server execution faults. They do share
+// the common.proto Severity enum, so severity is already canonical.
+//
+// Consequence for clients: FormService does NOT expose machine-readable
+// ErrorDetail.code / category / retryability on its submission path. Form
+// errors are user-correctable input problems, not retryable RPC faults; the
+// gRPC status carries transport/RPC-level failures, and ValidationIssue
+// carries the per-field user feedback. If a future need arises to surface
+// canonical ErrorDetail on SubmitFormDataResponse it should be added
+// additively (a new field) rather than by replacing ValidationIssue, to keep
+// the v1 wire contract backward compatible.
 service FormService {
   // GetFormDefinition retrieves a form definition for mobile rendering.
   rpc GetFormDefinition(GetFormDefinitionRequest) returns (GetFormDefinitionResponse);
@@ -537,6 +559,10 @@ message SubmissionMetadata {
   map<string, string> custom_metadata = 7;
 }
 
+// SubmissionResult / ValidationIssue are FormService's bespoke,
+// user-facing validation outcome types. They intentionally do NOT use the
+// shared execution_types.proto ErrorDetail; see the divergence note on the
+// FormService definition above for the rationale.
 message SubmissionResult {
   bool success = 1;
   string message = 2;
@@ -544,6 +570,10 @@ message SubmissionResult {
   int64 server_timestamp = 4;
 }
 
+// ValidationIssue is per-field, end-user-facing form validation feedback. It is
+// deliberately not execution_types.proto ErrorDetail (no machine-readable
+// code / category / retryability); it shares the canonical common.proto
+// Severity enum. See the FormService divergence note above.
 message ValidationIssue {
   string field_id = 1;
   Severity severity = 2;


### PR DESCRIPTION
## Finding addressed (round-4 audit, S2)

### FormService does not use canonical ErrorDetail (`geospatial/v1/form_service.proto:540`)
FormService is the only structured-error surface not using the shared `execution_types.proto` `ErrorDetail`. It reports outcomes via the bespoke `SubmissionResult` / `ValidationIssue` pair, which lack code/category/retryability — and unlike SpecService (which carries an explicit "Intentional divergence" block) the divergence was undocumented.

## Approach
The audit recommendation was: **"Document the divergence or add ErrorDetail additively."** This PR takes the documentation slice — the safe, non-wire-changing option that matches how SpecService records its rationale. Adding `ErrorDetail` to `SubmitFormDataResponse` is a wire-contract decision left to maintainers (see not-done below).

## Changes (comment-only)
- Added an "Intentional divergence from the shared error model" block to the `FormService` definition explaining that `SubmissionResult` / `ValidationIssue` model per-field, end-user-facing form validation feedback (not machine-driven RPC faults), already share the canonical `Severity` enum, and that any future `ErrorDetail` exposure should be added **additively** to preserve v1 wire compatibility.
- Added pointer comments on the `SubmissionResult` / `ValidationIssue` types.

## Verification
- `buf lint` and `buf format --diff --exit-code` pass.
- `buf breaking` clean against `origin/trunk` for `form_service.proto` (comment-only; no wire change). Note: `buf breaking` against the *stale local* `trunk` branch ref surfaces pre-existing SpecService/severity changes unrelated to this PR — confirmed clean against `origin/trunk` (the actual base).

## Not done (maintainer decision)
- Additively adding `ErrorDetail` to `SubmitFormDataResponse` — a wire-contract change requiring product/error-model sign-off.