### PR TITLE
fix(buf): generate C# service clients from aggregate template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,10 @@ Shared type modules: `common.proto`, `spatial_types.proto`,
 
 Generation flow: `buf.gen.yaml` (v2) drives multi-language output to `gen/`
 with managed-mode package prefixes (`github.com/geospatial-grpc/proto-go`,
-`io.grpc.geospatial`, C# base namespace `GeospatialGrpc`). The .NET package
+`io.grpc.geospatial`). C# uses no `base_namespace` override: managed mode
+derives the namespace from the proto package (`geospatial.v1` -> `Geospatial.V1`),
+and a `base_namespace` that is not a prefix of that namespace makes the C#
+plugin hard-fail (so `GeospatialGrpc` must not be set). The .NET package
 instead compiles the protos directly via `Grpc.Tools` (`GrpcServices=Both`).
 
 ## Directory Layout

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -15,6 +15,8 @@ plugins:
   # published NuGet package.
   - remote: buf.build/protocolbuffers/csharp:v35.1
     out: gen/csharp
+  - remote: buf.build/grpc/csharp:v1.81.1
+    out: gen/csharp
 
   # Go
   - remote: buf.build/protocolbuffers/go:v1.36.11


### PR DESCRIPTION
## Summary

Two coupled C# code-generation defects in the canonical templates/docs, found in the round-5 release audit.

### 1. Aggregate `buf.gen.yaml` omits the `grpc/csharp` plugin (S2)

`buf.gen.yaml:16` — the aggregate C# block listed only `protocolbuffers/csharp` and was **missing `grpc/csharp`**, even though its own comment asserts it "matches buf.gen.csharp.yaml and the published NuGet package." Every other language pairs its protobuf plugin with its gRPC plugin (Go, Java, Python); C# was the lone gap.

Consequence: `buf generate` — the exact command `docs/getting-started.md` Step 3 tells C# users to run — emitted message/enum types but **no `*ServiceClient` stubs**. The Step 5 sample (`new FeatureService.FeatureServiceClient(channel)` + `QueryFeaturesAsync`) would not compile against that output. The NuGet package is unaffected (it uses `Grpc.Tools` with `GrpcServices=Both`), so only the documented local-codegen C# path was broken, and CI's per-language `generate` job uses `buf.gen.csharp.yaml` — so this landed green.

Fix: add `grpc/csharp:v1.81.1` (pinned to match `buf.gen.csharp.yaml`) to the aggregate template.

### 2. `AGENTS.md` documents a wrong/breaking C# base namespace (S2)

`AGENTS.md:115` claimed generation uses "C# base namespace `GeospatialGrpc`". No `base_namespace` override is — or can be — set: managed mode derives `Geospatial.V1` from the proto package, and a `base_namespace` that is not a prefix of that namespace makes the csharp plugin **hard-fail**. All real consumers (`examples/dotnet/Program.cs`, getting-started, the smoke test) use `Geospatial.V1`. A contributor trusting AGENTS.md and adding `base_namespace=GeospatialGrpc` would break C# generation. Corrected the text to match `buf.gen.yaml`'s own comment.

## Verification

Ran `buf generate` with the fixed aggregate C# block:
- Output namespace: `Geospatial.V1` (matches all consumers)
- 14 `*ServiceClient` classes generated (`FeatureServiceClient`, `FormServiceClient`, etc.)

Empirically confirmed the inverse: setting `base_namespace=GeospatialGrpc` fails with `Namespace Geospatial.V1 is not a prefix namespace of base namespace GeospatialGrpc`.

## Findings addressed
- `buf.gen.yaml:16` — aggregate template missing grpc/csharp plugin
- `AGENTS.md:115` — stale/incorrect C# base-namespace claim