### PR TITLE
docs: replace raw HTTP examples with supported clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
 
+      - name: Enforce maintained documentation command policy
+        run: |
+          if git grep -n -i -w curl -- '*.md' '*.mdx' '*.rst' '*.txt'; then
+            echo "::error::Maintained documentation must use supported SDK, CLI, or API-reference workflows."
+            exit 1
+          fi
+
       - name: Install Buf CLI
         run: |
           curl -fsSL -o "${RUNNER_TEMP}/buf" "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64"

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -141,8 +141,8 @@ conformance/fetch-fixtures.sh --version 0.1.0-alpha.1 --dest ./conformance-fixtu
 `fetch-fixtures.sh`:
 
 1. downloads `conformance-fixtures-<version>.tar.gz` (+ `.sha256`) from the
-   `v<version>` GitHub Release of `honua-io/geospatial-grpc` (via `gh release
-   download` if available, else `curl`/`wget`);
+   `v<version>` GitHub Release of `honua-io/geospatial-grpc` (preferring
+   `gh release download` and using its portable fallback otherwise);
 2. verifies the tarball SHA-256;
 3. extracts it and re-verifies **every** file against the in-tarball
    `SHA256SUMS`;
@@ -151,17 +151,9 @@ conformance/fetch-fixtures.sh --version 0.1.0-alpha.1 --dest ./conformance-fixtu
    `--dest`.
 
 Consumers do not need this repo checked out — copy `fetch-fixtures.sh` into the
-consumer (or vendor it once) and call it with the pinned version. Equivalent raw
-download, if you prefer not to use the helper:
-
-```bash
-v=0.1.0-alpha.1
-base="https://github.com/honua-io/geospatial-grpc/releases/download/v${v}"
-curl -fsSLO "${base}/conformance-fixtures-${v}.tar.gz"
-curl -fsSLO "${base}/conformance-fixtures-${v}.tar.gz.sha256"
-sha256sum -c "conformance-fixtures-${v}.tar.gz.sha256"
-tar -xzf "conformance-fixtures-${v}.tar.gz"
-```
+consumer (or vendor it once) and call it with the pinned version. Use the helper
+instead of reconstructing the release download: it verifies both the release
+checksum and every file in the extracted fixture set.
 
 ### Verifying with the bundled harness
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,10 +17,10 @@ This guide will help you quickly get up and running with the Geospatial gRPC pro
 brew install bufbuild/buf/buf
 
 # Linux/WSL
-curl -sSL https://github.com/bufbuild/buf/releases/latest/download/buf-Linux-x86_64.tar.gz | tar -xzf - -C /usr/local buf/bin/buf
+npm install --global @bufbuild/buf
 
 # Windows
-# Download from: https://github.com/bufbuild/buf/releases
+npm install --global @bufbuild/buf
 ```
 
 ### Verify Installation
@@ -769,12 +769,16 @@ Make sure you've correctly installed the generated files in your project and imp
 
 ### Connection Issues
 
-Verify the server endpoint and ensure your client can reach it:
+Verify the server endpoint by running one of the typed client examples. A
+successful RPC proves DNS, TLS, HTTP/2, and service routing together:
 
 ```bash
-# Test basic connectivity
-curl -v https://api.example.com/health
+dotnet run --project examples/dotnet
 ```
+
+For a different endpoint, update the example's `GrpcChannel.ForAddress(...)`
+value before running it. Inspect the resulting `RpcException.StatusCode` when a
+connection or service call fails.
 
 ### SSL/TLS Issues
 


### PR DESCRIPTION
Part of honua-migrate#101. Replaces raw install/connectivity snippets with npm and the typed .NET example, and keeps fixture retrieval helper-only. Checks: maintained-doc scan and diff check.