### PR TITLE
ci: pin OIDC reusable workflow refs and scope security permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,17 +8,25 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+# Keep the workflow-level grant read-only; write scopes are granted per job
+# below so a compromise of one reusable workflow cannot use the other's
+# privileges (issue #51 / AUD-284).
 permissions:
   contents: read
-  security-events: write
-  id-token: write
-  actions: read
 
 jobs:
   trivy:
-    uses: honua-io/.github/.github/workflows/reusable-trivy.yml@main
+    permissions:
+      contents: read
+      security-events: write # upload SARIF
+    uses: honua-io/.github/.github/workflows/reusable-trivy.yml@024e410fbbe63768af68604a5dd07f361590f26d # main
     with:
       scan-type: fs
 
   scorecard:
-    uses: honua-io/.github/.github/workflows/reusable-scorecard.yml@main
+    permissions:
+      contents: read
+      actions: read # scorecard inspects workflow runs
+      security-events: write # upload SARIF
+      id-token: write # publish results to OpenSSF
+    uses: honua-io/.github/.github/workflows/reusable-scorecard.yml@024e410fbbe63768af68604a5dd07f361590f26d # main


### PR DESCRIPTION
Fixes #51

## Summary

Hardens `.github/workflows/security.yml` against the audit finding AUD-284: the reusable workflows from `honua-io/.github` were referenced at the mutable `main` ref while the calling workflow granted `id-token: write` and `security-events: write` globally, so a compromise of that branch could mint OIDC tokens and write security events in this repo.

## Changes Made

- Pinned both reusable workflow refs to the current `main` commit SHA (`024e410fbbe63768af68604a5dd07f361590f26d`), with a `# main` ref comment per the existing pinning convention.
- Dropped the workflow-level write grants to `contents: read` and moved write scopes to per-job `permissions`:
  - `trivy`: `contents: read`, `security-events: write` (SARIF upload only).
  - `scorecard`: `contents: read`, `actions: read`, `security-events: write`, `id-token: write` — `id-token: write` is now scoped to the scorecard job only, as the audit prescribes.
- Each job grant is the minimal superset of what the pinned reusable workflow's jobs actually request (verified against `reusable-trivy.yml` and `reusable-scorecard.yml` at the pinned SHA).

## Already resolved on trunk (not re-fixed)

AUD-285 (rolling date tags sharing the `v*` namespace used to select the breaking-change baseline) was already fixed on trunk by #61: per-push snapshot tags moved to the dedicated `ci-snapshot/` namespace, and the push-time breaking check selects the highest-semver `v*` release tag (`git tag --list 'v*' --sort=-version:refname`) instead of the most recently pushed tag. #67 added a regression meta-test for the breaking gate. No `ci.yml` changes were needed.

## Validation

- YAML syntax validated (actionlint not available in this environment; workflows cannot be executed locally).
- Caller job permissions cross-checked against the called workflows' declared job permissions at the pinned SHA.

## Breaking Changes

None.