### PR TITLE
ci(publish): add a nuget.org publish lane gated on NUGET_API_KEY

### DIFF
--- a/.github/workflows/publish-dotnet-protocol.yml
+++ b/.github/workflows/publish-dotnet-protocol.yml
@@ -162,3 +162,20 @@ jobs:
             --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             --api-key "${{ secrets.GITHUB_TOKEN }}" \
             --skip-duplicate
+
+      - name: Publish to nuget.org
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        shell: bash
+        run: |
+          # The public feed is what lets downstream SDKs (honua-sdk-dotnet#264)
+          # ship restorable packages to nuget.org. Skip loudly, never fail,
+          # when the credential is not configured.
+          if [[ -z "${NUGET_API_KEY}" ]]; then
+            echo "::warning::NUGET_API_KEY is not configured — packages shipped to GitHub Packages only, not nuget.org."
+            exit 0
+          fi
+          dotnet nuget push nupkgs/*.nupkg \
+            --source "https://api.nuget.org/v3/index.json" \
+            --api-key "${NUGET_API_KEY}" \
+            --skip-duplicate


### PR DESCRIPTION
Downstream stable SDKs cannot publish restorable packages to nuget.org while `Geospatial.Grpc` lives only on the authenticated GitHub Packages feed — the blocker tracked as honua-sdk-dotnet#264.

Adds a `Publish to nuget.org` step after the GitHub Packages push: when the `NUGET_API_KEY` secret is configured it pushes the same artifacts to nuget.org with `--skip-duplicate`; when absent it skips with a `::warning::` instead of failing, so the existing GitHub Packages release path is unchanged until the credential exists. These packages are unsigned, which nuget.org accepts (it repository-signs all uploads).

Once the secret is in place, dispatching this workflow on tags `v0.1.0-alpha.2` (the version honua-sdk-dotnet pins) and `v0.1.0-alpha.3` puts both on the public feed.